### PR TITLE
KIP-0017: wallet-connect-v2 sign-api session spec

### DIFF
--- a/kip-0017.md
+++ b/kip-0017.md
@@ -14,17 +14,17 @@ Created: 2022-11-15
     - [Example Pairing Proposal Request and Settlement Response](#example-pairing-proposal-request-and-settlement-response)
     - [WalletConnect Proposal Request](#walletconnect-proposal-request)
     - [WalletConnect Settlement Response](#walletconnect-settlement-response)
-    - [Wallet Connect Chain IDs](#wallet-connect-chain-ids)
-    - [Wallet Connect Accounts](#wallet-connect-accounts)
+    - [WalletConnect Chain IDs](#wallet-connect-chain-ids)
+    - [WalletConnect Accounts](#wallet-connect-accounts)
     - [WalletConnect Methods](#walletconnect-methods)
       - [kadena_getAccounts_v1](#kadena_getaccounts_v1)
         - [Example kadena_getAccounts_v1 Request and Response](#example-kadena_getaccounts_v1-request-and-response)
         - [kadena_getAccounts_v1 Request](#kadena_getaccounts_v1-request)
         - [kadena_getAccounts_v1 Response](#kadena_getaccounts_v1-response)
-      - [kadena_quickSign_v1](#kadena_quicksign_v1)
-        - [Example kadena_quickSign_v1 Request and Response](#example-kadena_quicksign_v1-request-and-response)
-        - [kadena_quickSign_v1 Request](#kadena_quicksign_v1-request)
-        - [kadena_quickSign_v1 Response](#kadena_quicksign_v1-response)
+      - [kadena_quicksign_v1](#kadena_quicksign_v1)
+        - [Example kadena_quicksign_v1 Request and Response](#example-kadena_quicksign_v1-request-and-response)
+        - [kadena_quicksign_v1 Request](#kadena_quicksign_v1-request)
+        - [kadena_quicksign_v1 Response](#kadena_quicksign_v1-response)
       - [kadena_sign_v1](#kadena_sign_v1)
         - [Example kadena_sign_v1 Request and Response](#example-kadena_sign_v1-request-and-response)
         - [kadena_sign_v1 Request](#kadena_sign_v1-request)
@@ -38,7 +38,7 @@ Created: 2022-11-15
 # Motivation
 
 This KIP proposes that the Kadena ecosystem implement the
-[Wallet Connect v2 Sign API](https://docs.walletconnect.com/2.0/api/sign). This
+[WalletConnect v2 Sign API](https://docs.walletconnect.com/2.0/api/sign). This
 API allows for establishing a secure channel for communicating between dApps and
 wallets in a platform-agnostic manner.
 
@@ -129,14 +129,14 @@ The response for the Proposal contains a `namespaces` object with the following 
     1.2. `methods`: `Array<string>` - an array of [Methods](#walletconnect-methods) available.\
     1.3. `events`: `Array<string>` - an array of [Events](#walletconnect-events) available.
 
-## Wallet Connect Chain IDs
+## WalletConnect Chain IDs
 
-Chain IDs are Wallet Connect’s way of identifying specific blockchains within an ecosystem.
+Chain IDs are WalletConnect’s way of identifying specific blockchains within an ecosystem.
 
 They are defined by the [CAIP-2 standard](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md) and are formatted as:
 
 ```
-    <namespace> + ":" + <reference>
+<namespace> + ":" + <reference>
 ```
 - `<namespace>`: `string` - always defined as "kadena".
 - `<reference>`: `string` - a unique network ID within the blockchain ecosystem (e.g. `testnet04`, `mainnet01`).
@@ -153,19 +153,19 @@ These are valid Chain IDs:
 > We are displaying Kadena `chainId` information in the [`kadena_getAccounts_v1`](#kadena_getAccounts_v1) method.
 
 
-## Wallet Connect Accounts
+## WalletConnect Accounts
 
-Accounts are Wallet Connect's way of specifying control over signing privileges.
+Accounts are WalletConnect's way of specifying control over signing privileges.
 
 They are defined by the [CAIP-10 standard](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md), and are formatted as:
 ```
-    <chain_id> + ":" + <account_address>
+<chain_id> + ":" + <account_address>
 ```
-- `<chain_id>`: `string` - the Wallet Connect [Chain ID](#wallet-connect-chain-ids).
+- `<chain_id>`: `string` - the WalletConnect [Chain ID](#wallet-connect-chain-ids).
 - `<account_address>`: `string` - the public key available for signing by the wallet.
 
 ```jsonc
-// Wallet Connect Account Example
+// WalletConnect Account Example
 
 "kadena:mainnet01:38298612cc2d5e841a232bd08413aa5304f9ef3251575ee182345abc3807dd89"
 ```
@@ -180,7 +180,7 @@ The use of account names that can be derived from the public key (i.e. `k:`-acco
 
 ## WalletConnect Methods
 
-Wallet Connect methods are ways for dApps to interact with a wallet using predefined method identifiers and an optional payload.
+WalletConnect methods are ways for dApps to interact with a wallet using predefined method identifiers and an optional payload.
 
 The methods available for Kadena are:
 
@@ -281,7 +281,7 @@ This method also expects a `params` object with the following properties:
 
 1. `params`: `Object`\
     1.1. `accounts`: `Array<Object>`\
-    __ 1.1.1 `account`: `string` - a [Wallet Connect Account](#wallet-connect-accounts) for which the Kadena account names are requested.\
+    __ 1.1.1 `account`: `string` - a [WalletConnect Account](#wallet-connect-accounts) for which the Kadena account names are requested.\
     __ 1.1.2 `contracts`: `Array<string>` (optional) - array of contracts for which the Kadena account name is requested. Returns all known Kadena accounts when omitted.
 
 > **NB**: We choose to not add chains to the [getAccounts_v1 request](#kadena_getAccounts_v1-Request) since it would
@@ -293,8 +293,8 @@ The method response expects a `result` object with the following properties:
 
 1. `result`: `Object`\
     1.1. `accounts`: `Array<Object>`\
-    __ 1.1.1 `account`: `string` - the requested [Wallet Connect Account](#wallet-connect-accounts).\
-    __ 1.1.2 `publicKey`: `string` - the requested public key, which was extracted from the Wallet Connect account.\
+    __ 1.1.1 `account`: `string` - the requested [WalletConnect Account](#wallet-connect-accounts).\
+    __ 1.1.2 `publicKey`: `string` - the requested public key, which was extracted from the WalletConnect account.\
     __ 1.1.3 `kadenaAccounts`: `Array<Object>`\
     ____ 1.1.3.1 `name`: `string` - the account name, as stored in the blockchain, for the specified contract.\
     ____ 1.1.3.2 `contract`: `string` - the contract on which this account name is present.\
@@ -314,14 +314,14 @@ The method response expects a `result` object with the following properties:
 QuickSign is part of the [Kadena Signing API](https://github.com/kadena-io/signing-api) and was defined in [kip-0015 (QuickSign Signing API v1)](https://github.com/kadena-io/KIPs/blob/master/kip-0015.md).
 This method allows the wallet to show the user multiple transactions that need signature approval.
 
-#### Example kadena_quickSign_v1 Request and Response
+#### Example kadena_quicksign_v1 Request and Response
 
 ```jsonc
-// kadena_quickSign_v1 Method Request
+// kadena_quicksign_v1 Method Request
 {
   "id": 1,
   "jsonrpc": "2.0",
-  "method": "kadena_quickSign_v1",
+  "method": "kadena_quicksign_v1",
   "params": {
     "commandSigDatas": [CommandSigData] // type defined in KIP-15
   }
@@ -329,7 +329,7 @@ This method allows the wallet to show the user multiple transactions that need s
 ````
 
 ```jsonc
-// Successful kadena_quickSign_v1 Response
+// Successful kadena_quicksign_v1 Response
 {
     "id": 1,
     "jsonrpc": "2.0",
@@ -342,7 +342,7 @@ This method allows the wallet to show the user multiple transactions that need s
 or
 
 ```jsonc
-// Failed kadena_quickSign_v1 Response
+// Failed kadena_quicksign_v1 Response
 {
     "id": 1,
     "jsonrpc": "2.0",
@@ -353,9 +353,9 @@ or
 
 ```
 
-#### kadena_quickSign_v1 Request
+#### kadena_quicksign_v1 Request
 
-This method expects a `method` field that is set to `"kadena_quickSign_v1"`.
+This method expects a `method` field that is set to `"kadena_quicksign_v1"`.
 
 This method also expects a `params` object with the following properties:
 
@@ -363,7 +363,7 @@ This method also expects a `params` object with the following properties:
     1.1. `commandSigDatas`: `Array<Object>` - A list of [`CommandSigData`](https://github.com/kadena-io/KIPs/blob/master/kip-0015.md#commandsigdata) to sign.
 
 
-#### kadena_quickSign_v1 Response
+#### kadena_quicksign_v1 Response
 
 If signing was successful, then the method response expects a `result` object with the following properties:
 
@@ -428,7 +428,7 @@ This is subject to change in the future as we understand the workflows more thro
 
 However, any future Kadena event names will be formatted as:
 ```
-    kadena_<eventName>_v<eventVersionNumber>
+kadena_<eventName>_v<eventVersionNumber>
 ```
 - `<eventName>`: `string` - name of the event in camelCase format.
 - `<eventVersionNumber>`: `integer` - the version number of the event to allow for future upgradeability
@@ -442,11 +442,11 @@ Several options were considered when discussing what information to include
 in the `accounts` section of the initial pairing response.
 
 However, the following reasons forced us to only include the public keys
-(prefixed with Kadena's Wallet Connect Chain ID):
+(prefixed with Kadena's WalletConnect Chain ID):
 
 1. Kadena fungible contracts (specifically the `coin` contract) have a maximum account name length of 256, but
    the [CAIP-10 standard](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md)
-   limits wallet connect account names to a maximum of 128 characters.
+   limits WalletConnect account names to a maximum of 128 characters.
 2. We considered only supporting `k:` accounts, as they're built from
    `k`:`publicKey`, but we want this response to be generic for all accounts
    that could exist on the Kadena blockchain.
@@ -457,7 +457,7 @@ method into the pairing process with the wallet.
 This will allow them to support multi-sig accounts (e.g. `w:`-accounts) and
 other means of signing transactions.
 
-We do **NOT** recommend extracting the `publicKey` from the Wallet Connect account
+We do **NOT** recommend extracting the `publicKey` from the WalletConnect account
 and just adding a `k:` in front of it.
 
 

--- a/kip-0017.md
+++ b/kip-0017.md
@@ -1,0 +1,112 @@
+---
+KIP: 0017
+Title: wallet-connect-v2-sign implementation spec
+Author: Jacquin Mininger @jmininger, Doug Beardsley @mightybyte
+Status: Draft
+Type: Standard
+Category: Interface
+Created: 2022-11-15
+---
+
+# Abstract
+
+We propose that the Kadena ecosystem use the [wallet-connect-v2 sign-api](https://docs.walletconnect.com/2.0/introduction/sign) to establish a secure channel for communication between dapps and wallets that is platform-agnostic.
+
+# Motivation
+
+- The prior signing-api requires the wallet to be able to run a http server. This is often times not possible for browser-based and mobile wallets
+- The protocol is a tried and tested way of abstracting the communication between dapps and wallets across all devices, and removes the burden of having to maintain a kadena-specific implementation
+- Wallet connect will allow multi-protocol wallets/dapps that are already using the protocol to seamlessly integrate with the kadena ecosystem
+
+# Specification
+
+## Namespace
+
+- Namespaces are a way of identifying blockchain ecosystems in the wallet-connect protocol.
+- In WC namespaces must abide by the [CAIP-2 standard](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md) which imposes the following pattern-based restriction: `[-a-z0-9]{3,8}`
+- The namespace for kadena is `kadena`
+
+## Chain ID
+
+- Chain IDs are wallet-connect’s way of identifying specific blockchains within an ecosystem. They are defined by the [CAIP-2 standard](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md), and are formatted as `namespace + ":" + reference`
+- A reference refers to a specific network-id within the kadena ecosystem
+- **NOTE**: Chain IDs in the wallet protocol ARE NOT the same as chainweb/pact’s version of “chain-id” — they are much more similar to `networkId`
+
+These are valid kadena chain-ids
+
+```
+# Kadena mainnet
+kadena:mainnet01
+
+# Current kadena testnet
+kadena:testnet04
+
+# Kadena devnet
+kadena:development
+```
+
+## Accounts
+
+- Accounts in wallet connect are used to specify control over signing privileges
+- They must conform to [CAIP-10](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md) and are formatted: `chain_id + ":" + account_address`
+- **NOTE**: Wallet-connect’s `account_address` is NOT the same as pact’s coin account. Instead, they are analogous to pact’s `signer` ([see here](https://api.chainweb.com/openapi/pact.html#tag/model-payload))
+
+Here are some example accounts:
+
+```
+
+kadena:mainnet01:22ddc64851718e9d41d98b0f33d5e328ae5bbbbd97aed9885adac0f2d070ff9c
+
+kadena:testnet04:38298612cc2d5e841a232bd08413aa5304f9ef3251575ee182345abc3807dd89
+```
+
+## Default Methods
+
+- The supported methods are:
+
+```
+kadena_sign_v1
+kadena_quicksign_v1
+```
+
+- The params can be found in the [kadena-signing-api](https://kadena-io.github.io/signing-api/). Future methods may be added and will be documented there
+
+## Events
+
+- At the moment we see no need to standardize any events and believe that most usecases can be handled at the kadena-protocol level that sits atop wallet connect. This is subject to change in the future as we understand the workflows more through extended use of the protocol
+
+## SLIP-0044
+While not required in the namespace proposal process, a network's SLIP-0044 value is used throughout the wallet connect demo code.
+Kadena's coin type is 626 as documented in https://github.com/satoshilabs/slips/blob/master/slip-0044.md
+
+# Example Proposal and Response
+
+```json
+# Proposal namespace request
+{
+  "kadena": {
+    "chains": ["kadena:mainnet01", "kadena:testnet04", "kadena:development"],
+    "methods": ["kadena_quicksign_v1"],
+    "events": []
+  }
+}
+```
+
+```json
+# Session namespace response
+{
+  "kadena": {
+    "accounts": [
+      "kadena:mainnet01:38298612cc2d5e841a232bd08413aa5304f9ef3251575ee182345abc3807dd89",
+      "kadena:testnet04:38298612cc2d5e841a232bd08413aa5304f9ef3251575ee182345abc3807dd89",
+      "kadena:testnet04:22ddc64851718e9d41d98b0f33d5e328ae5bbbbd97aed9885adac0f2d070ff9c"
+    ],
+    "methods": ["kadena_quicksign_v1"],
+    "events": []
+    }
+}
+```
+
+# ****Backwards Compatibility****
+
+- As we work on phasing out the tradition signing-api exposed on localhost port 9467 we suggest dapps allow users to select between a legacy and wallet-connect option when connecting their wallet

--- a/kip-0017.md
+++ b/kip-0017.md
@@ -1,6 +1,6 @@
 ---
 KIP: 0017
-Title: wallet-connect-v2-sign implementation spec
+Title: walletconnect-v2-sign implementation spec
 Author: Jacquin Mininger @jmininger, Doug Beardsley @mightybyte, Linda Ortega @lindaortega, Jermaine Jong @jermaine150, Albert Groothedde @alber70g
 Status: Final
 Type: Standard
@@ -14,8 +14,8 @@ Created: 2022-11-15
     - [Example Pairing Proposal Request and Settlement Response](#example-pairing-proposal-request-and-settlement-response)
     - [WalletConnect Proposal Request](#walletconnect-proposal-request)
     - [WalletConnect Settlement Response](#walletconnect-settlement-response)
-    - [WalletConnect Chain IDs](#wallet-connect-chain-ids)
-    - [WalletConnect Accounts](#wallet-connect-accounts)
+    - [WalletConnect Chain IDs](#walletconnect-chain-ids)
+    - [WalletConnect Accounts](#walletconnect-accounts)
     - [WalletConnect Methods](#walletconnect-methods)
       - [kadena_getAccounts_v1](#kadena_getaccounts_v1)
         - [Example kadena_getAccounts_v1 Request and Response](#example-kadena_getaccounts_v1-request-and-response)
@@ -116,7 +116,7 @@ This contains information on which of the requested items it supports.
 WalletConnect dictates a `requiredNamespaces` property that contains:
 
 1. `requiredNamespaces`: `Object`\
-    1.1. `chains`: `Array<string>` - an array of [Chain IDs](#wallet-connect-chain-ids) requested.\
+    1.1. `chains`: `Array<string>` - an array of [Chain IDs](#walletconnect-chain-ids) requested.\
     1.2. `methods`: `Array<string>` - an array of [Methods](#walletconnect-methods) requested.\
     1.3. `events`: `Array<string>` - an array of [Events](#walletconnect-events) requested.
 
@@ -125,7 +125,7 @@ WalletConnect dictates a `requiredNamespaces` property that contains:
 The response for the Proposal contains a `namespaces` object with the following properties:
 
 1. `namespaces`: `Object`\
-    1.1. `accounts`: `Array<string>` - an array of [Accounts](#wallet-connect-accounts) availble for signing.\
+    1.1. `accounts`: `Array<string>` - an array of [Accounts](#walletconnect-accounts) availble for signing.\
     1.2. `methods`: `Array<string>` - an array of [Methods](#walletconnect-methods) available.\
     1.3. `events`: `Array<string>` - an array of [Events](#walletconnect-events) available.
 
@@ -161,7 +161,7 @@ They are defined by the [CAIP-10 standard](https://github.com/ChainAgnostic/CAIP
 ```
 <chain_id> + ":" + <account_address>
 ```
-- `<chain_id>`: `string` - the WalletConnect [Chain ID](#wallet-connect-chain-ids).
+- `<chain_id>`: `string` - the WalletConnect [Chain ID](#walletconnect-chain-ids).
 - `<account_address>`: `string` - the public key available for signing by the wallet.
 
 ```jsonc
@@ -197,7 +197,7 @@ kadena_<methodName>_v<methodVersionNumber>
 
 ### kadena_getAccounts_v1
 
-This method returns the Kadena account names associated with a given [WalletConnect account](#wallet-connect-accounts) and contract(s) on the Kadena blockchain.
+This method returns the Kadena account names associated with a given [WalletConnect account](#walletconnect-accounts) and contract(s) on the Kadena blockchain.
 #### Example kadena_getAccounts_v1 Request and Response
 
 ```jsonc
@@ -281,7 +281,7 @@ This method also expects a `params` object with the following properties:
 
 1. `params`: `Object`\
     1.1. `accounts`: `Array<Object>`\
-    __ 1.1.1 `account`: `string` - a [WalletConnect Account](#wallet-connect-accounts) for which the Kadena account names are requested.\
+    __ 1.1.1 `account`: `string` - a [WalletConnect Account](#walletconnect-accounts) for which the Kadena account names are requested.\
     __ 1.1.2 `contracts`: `Array<string>` (optional) - array of contracts for which the Kadena account name is requested. Returns all known Kadena accounts when omitted.
 
 > **NB**: We choose to not add chains to the [getAccounts_v1 request](#kadena_getAccounts_v1-Request) since it would
@@ -293,7 +293,7 @@ The method response expects a `result` object with the following properties:
 
 1. `result`: `Object`\
     1.1. `accounts`: `Array<Object>`\
-    __ 1.1.1 `account`: `string` - the requested [WalletConnect Account](#wallet-connect-accounts).\
+    __ 1.1.1 `account`: `string` - the requested [WalletConnect Account](#walletconnect-accounts).\
     __ 1.1.2 `publicKey`: `string` - the requested public key, which was extracted from the WalletConnect account.\
     __ 1.1.3 `kadenaAccounts`: `Array<Object>`\
     ____ 1.1.3.1 `name`: `string` - the account name, as stored in the blockchain, for the specified contract.\

--- a/kip-0017.md
+++ b/kip-0017.md
@@ -48,7 +48,7 @@ This is beneficial to Kadena for the following reasons:
   communicate with each other.
 - The Wallet Connect (WC) protocol is tried and
   tested across all devices and it removes the burden of having to maintain a
-  kadena-specific implementation.
+  Kadena-specific implementation.
 - Wallets and dApps that are already using the WC protocol will have an easier
   time integrating with the Kadena ecosystem.
 - Kadena's previous Signing API required the wallet to be able to run an http
@@ -155,7 +155,7 @@ These are valid Chain IDs:
 
 ## Wallet Connect Accounts
 
-Accounts are Wallet Connect's way of specifying control over signing priviledges.
+Accounts are Wallet Connect's way of specifying control over signing privileges.
 
 They are defined by the [CAIP-10 standard](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md), and are formatted as:
 ```
@@ -442,7 +442,7 @@ However, any future Kadena event names will be formatted as:
 - `<eventName>`: `string` - name of the event in camelCase format.
 - `<eventVersionNumber>`: `integer` - the version number of the event.
 
-> **NB**: All event names will be versioned to allow for facilitate future
+> **NB**: All event names will be versioned to allow for future
 > upgradability of the Wallet Connect events APIs.
 
 
@@ -459,15 +459,15 @@ However, the following reasons forced us to only include the public keys
 1. Kadena fungible contracts (specifically the `coin` contract) have a maximum account name length of 256, but
    the [CAIP-10 standard](https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-10.md)
    limits wallet connect account names to a maximum of 128 characters.
-2. We considered only supporting `k:` accounts, as they're build from
+2. We considered only supporting `k:` accounts, as they're built from
    `k`:`publicKey`, but we want this response to be generic for all accounts
    that could exist on the Kadena blockchain.
 
-Therefore, we **strongly** advice builders to integrate the [`kadena_getAccounts_v1`](#kadena_getAccounts_v1)
+Therefore, we **strongly** advise builders to integrate the [`kadena_getAccounts_v1`](#kadena_getAccounts_v1)
 method into the pairing process with the wallet.
 
 This will allow them to support multi-sig accounts (e.g. `w:`-accounts) and
-other means of singing transactions.
+other means of signing transactions.
 
 We do **NOT** recommend extracting the `publicKey` from the Wallet Connect account
 and just adding a `k:` in front of it.

--- a/kip-0017.md
+++ b/kip-0017.md
@@ -480,7 +480,7 @@ value is used throughout the WalletConnect demo code.
 
 Kadena's coin type is
 **626** as documented in
-https://github.com/satoshilabs/slips/blob/master/slip-0044.md.
+(SLIP-0044)[https://github.com/satoshilabs/slips/blob/master/slip-0044.md].
 
 # Backwards Compatibility
 

--- a/kip-0017.md
+++ b/kip-0017.md
@@ -46,7 +46,7 @@ This is beneficial to Kadena for the following reasons:
 
 - The Kadena ecosystem doesn't have a standard protocol for wallets and dApps to
   communicate with each other.
-- The Wallet Connect (WC) protocol is tried and
+- The WalletConnect (WC) protocol is tried and
   tested across all devices and it removes the burden of having to maintain a
   Kadena-specific implementation.
 - Wallets and dApps that are already using the WC protocol will have an easier
@@ -174,12 +174,9 @@ They are defined by the [CAIP-10 standard](https://github.com/ChainAgnostic/CAIP
 > represent an account in a Kadena fungible contract (e.g. `coin`).
 > Read the motivation for this in [Accounts vs. Public Keys](#accounts-vs-public-keys).
 
-Some users will want to know which account names in a Kadena fungible contract are associated with the public keys returned by Wallet Connect.
+After the initial pairing with the wallet via WalletConnect, the Kadena accounts relevant for each public key can be requested by calling [getAccounts](#kadena_getaccounts_v1).
 
-These users have two options:
-- Some account names can be derived from the public key (e.g. `k:` accounts that are defined as `k:<public_key>`).
-- For all other cases, the [`kadena_getAccounts_v1`](#kadena_getAccounts_v1)
-method can be called.
+The use of account names that can be derived from the public key (i.e. `k:`-accounts that are defined as `k:<public_key>`), is **highly discouraged** as implementing this will limit the end-users flexibility in which account to use, thus making dApps less generic.
 
 ## WalletConnect Methods
 
@@ -188,25 +185,19 @@ Wallet Connect methods are ways for dApps to interact with a wallet using predef
 The methods available for Kadena are:
 
 - [`kadena_getAccounts_v1`](#kadena_getAccounts_v1)
-- [`kadena_quickSign_v1`](#kadena_quicksign_v1)
+- [`kadena_quicksign_v1`](#kadena_quicksign_v1)
 - [`kadena_sign_v1`](#kadena_sign_v1)
 
 Any additional Kadena method names will be formatted as:
 ```
-    kadena_<methodName>_v<methodVersionNumber>
+kadena_<methodName>_v<methodVersionNumber>
 ```
 - `<methodName>`: `string` - name of the method in camelCase format.
-- `<methodVersionNumber>`: `integer` - the version number of the method.
-
-> **NB**: All method names will be versioned to allow for future
-> upgradability of the Wallet Connect method APIs.
+- `<methodVersionNumber>`: `integer` - the version number of the method. Methods are versioned to allow upgradeability
 
 ### kadena_getAccounts_v1
 
-This method returns the fungible account names associated with a specific Wallet Connect account (i.e. a prefixed public key) in the Kadena blockchain.
-
-These Wallet Connect accounts are retrieved from the `accounts` property of a [Paring response](#example-pairing-proposal-request-and-settlement-response).
-
+This method returns the Kadena account names associated with a given [WalletConnect account](#wallet-connect-accounts) and contract(s) on the Kadena blockchain.
 #### Example kadena_getAccounts_v1 Request and Response
 
 ```jsonc
@@ -290,11 +281,11 @@ This method also expects a `params` object with the following properties:
 
 1. `params`: `Object`\
     1.1. `accounts`: `Array<Object>`\
-    __ 1.1.1 `account`: `string` - a [Wallet Connect Account](#wallet-connect-accounts) (a prefixed public key) for which the Kadena account name is requested.\
-    __ 1.1.2 `contracts`: `Array<string>` (optional) - array of fungible contracts for which the Kadena account name is requested. Returns all known Kadena accounts if omitted.
+    __ 1.1.1 `account`: `string` - a [Wallet Connect Account](#wallet-connect-accounts) for which the Kadena account names are requested.\
+    __ 1.1.2 `contracts`: `Array<string>` (optional) - array of contracts for which the Kadena account name is requested. Returns all known Kadena accounts when omitted.
 
-> **NB**: We choose to not add chains to the [getAccounts_v1](#kadena_getAccounts_v1-Request) Request since it would
-> add complexity to the interface. The dApp can filter on the chains needed.
+> **NB**: We choose to not add chains to the [getAccounts_v1 request](#kadena_getAccounts_v1-Request) since it would
+> add complexity to the interface. The dApp can filter the necessary chains.
 
 #### kadena_getAccounts_v1 Response
 
@@ -318,7 +309,7 @@ The method response expects a `result` object with the following properties:
 
 
 
-### kadena_quickSign_v1
+### kadena_quicksign_v1
 
 QuickSign is part of the [Kadena Signing API](https://github.com/kadena-io/signing-api) and was defined in [kip-0015 (QuickSign Signing API v1)](https://github.com/kadena-io/KIPs/blob/master/kip-0015.md).
 This method allows the wallet to show the user multiple transactions that need signature approval.
@@ -440,10 +431,7 @@ However, any future Kadena event names will be formatted as:
     kadena_<eventName>_v<eventVersionNumber>
 ```
 - `<eventName>`: `string` - name of the event in camelCase format.
-- `<eventVersionNumber>`: `integer` - the version number of the event.
-
-> **NB**: All event names will be versioned to allow for future
-> upgradability of the Wallet Connect events APIs.
+- `<eventVersionNumber>`: `integer` - the version number of the event to allow for future upgradeability
 
 
 # Rationale for the spec


### PR DESCRIPTION
Update March 8, 2023:
We've updated the Wallet Connect Sign API v2 specifications for Kadena. Some of the major changes we introduced:
- Re-organization and re-wording of some section.
- Added specifications for a `getAccounts` method for retrieving Kadena account information from a public key.
- Made the method names versioned to allow for future upgradability.

We are aiming to finalize this KIP by the end of this week, so Friday, March 10, 2023.

