### PR TITLE
KIP-17: Proposal and Settlement Update

### DIFF
--- a/kip-0017.md
+++ b/kip-0017.md
@@ -111,8 +111,16 @@ This contains information on which of the requested items it supports.
 }
 ```
 
-There are also `optionalNamespaces` that **may** be included, but are not required in the settlement from the wallet.  
+There are also [`optionalNamespaces`](https://docs.walletconnect.com/2.0/specs/clients/sign/namespaces#proposal-namespace) that **may** be included, but are not required in the settlement from the wallet.  
 The structure for these is the same as the structure for the `requiredNamespaces`.
+
+The dApp uses the `requiredNamespaces` and `optionalNamespaces` fields to indicate to the wallet what chains, events, and methods it would like permission to.
+
+The main difference being that the wallet must grant access to all the chains, methods, and events specified in the `requiredNamespaces` in order to establish an active session. 
+
+Also, the WalletConnect library enforces that a Session Response's `accounts` field must contain at least one account per chain specified in `requiredNamespaces`.
+
+But it is up to the wallet to satisfy all, none, or some of the chains, methods, and events specified in the `optionalNamespaces` field.
 
 ### WalletConnect Proposal Request
 

--- a/kip-0017.md
+++ b/kip-0017.md
@@ -98,7 +98,7 @@ This contains information on which of the requested items it supports.
       "accounts": [
         "kadena:mainnet01:38298612cc2d5e841a232bd08413aa5304f9ef3251575ee182345abc3807dd89",
         "kadena:testnet04:38298612cc2d5e841a232bd08413aa5304f9ef3251575ee182345abc3807dd89",
-        "kadena:testnet04:22ddc64851718e9d41d98b0f33d5e328ae5bbbbd97aed9885adac0f2d070ff9c"
+        "kadena:development:22ddc64851718e9d41d98b0f33d5e328ae5bbbbd97aed9885adac0f2d070ff9c"
       ],
       "methods": [
         "kadena_getAccounts_v1",
@@ -110,6 +110,9 @@ This contains information on which of the requested items it supports.
   }
 }
 ```
+
+There are also `optionalNamespaces` that **may** be included, but are not required in the settlement from the wallet.  
+The structure for these is the same as the structure for the `requiredNamespaces`.
 
 ### WalletConnect Proposal Request
 


### PR DESCRIPTION
Multiple changes to match current actual implementation of WCv2.

1. the `kadena:development` namespace:chain had to be returned in the settlement, or the WCv2 library would have rejected the settlement response.
2. There are also `optionalNamespaces` now, I included a short note for that at the bottom of the example.

I'm building the flutter WalletConnect v2 library. These changes are the most up to date.