### PR TITLE
KIP-17: SigningCmdRequest -> SigningRequest

### DIFF
--- a/kip-0017.md
+++ b/kip-0017.md
@@ -387,7 +387,7 @@ Sign is part of the [Kadena Signing API](https://github.com/kadena-io/signing-ap
   "jsonrpc": "2.0",
   "method": "kadena_sign_v1",
   "params": {
-    SigningCmdRequest
+    SigningRequest
   }
 }
 ```
@@ -409,7 +409,7 @@ This method expects a `method` field that is set to `"kadena_sign_v1"`.
 
 This method also expects a `params` object with the following properties:
 
-1. `params`: `Object` - A [`SigningCmdRequest`](https://kadena-io.github.io/signing-api/#/definitions/SigningRequest) containing information the wallet needs to create and sign the transaction.
+1. `params`: `Object` - A [`SigningRequest`](https://kadena-io.github.io/signing-api/#/definitions/SigningRequest) containing information the wallet needs to create and sign the transaction.
 
 #### kadena_sign_v1 Response
 


### PR DESCRIPTION
The Wallet Signing API defines a `SigningRequest`, not a `SigningCmdRequest` object. I feel like having the names match is important here.