### PR TITLE
Added types kadena_getAccounts_v1

### DIFF
--- a/kip-0017.md
+++ b/kip-0017.md
@@ -279,8 +279,8 @@ This method expects a `method` field that is set to `"kadena_getAccounts_v1"`.
 
 This method also expects a `params` object with the following properties:
 
-1. `params`: `Object`\
-    1.1. `accounts`: `Array<Object>`\
+1. `params`: `GetAccountsRequest`\
+    1.1. `accounts`: `Array<AccountRequest>`\
     __ 1.1.1 `account`: `string` - a [WalletConnect Account](#walletconnect-accounts) for which the Kadena account names are requested.\
     __ 1.1.2 `contracts`: `Array<string>` (optional) - array of contracts for which the Kadena account name is requested. Returns all known Kadena accounts when omitted.
 
@@ -291,11 +291,11 @@ This method also expects a `params` object with the following properties:
 
 The method response expects a `result` object with the following properties:
 
-1. `result`: `Object`\
-    1.1. `accounts`: `Array<Object>`\
+1. `result`: `GetAccountsResponse`\
+    1.1. `accounts`: `Array<AccountResponse>`\
     __ 1.1.1 `account`: `string` - the requested [WalletConnect Account](#walletconnect-accounts).\
     __ 1.1.2 `publicKey`: `string` - the requested public key, which was extracted from the WalletConnect account.\
-    __ 1.1.3 `kadenaAccounts`: `Array<Object>`\
+    __ 1.1.3 `kadenaAccounts`: `Array<KadenaAccount>`\
     ____ 1.1.3.1 `name`: `string` - the account name, as stored in the blockchain, for the specified contract.\
     ____ 1.1.3.2 `contract`: `string` - the contract on which this account name is present.\
     ____ 1.1.3.3 `chains`: `Array<string>` - the chains on which this account name is present.


### PR DESCRIPTION
I have given a name to each of the different objects present in the `kadena_getAccounts_v1` just so there is normalcy in communication across languages.

These are the names I have given the objects in my [dart sdk](https://pub.dev/packages/kadena_dart_sdk)

Perhaps adding v1 at the end of each of the models would be a good idea.