### PR TITLE
KIP-17: Show correct KIP number Github preview

### DIFF
--- a/kip-0017.md
+++ b/kip-0017.md
@@ -1,5 +1,5 @@
 ---
-KIP: 0017
+KIP: 17
 Title: walletconnect-v2-sign implementation spec
 Author: Jacquin Mininger @jmininger, Doug Beardsley @mightybyte, Linda Ortega @lindaortega, Jermaine Jong @jermaine150, Albert Groothedde @alber70g
 Status: Final


### PR DESCRIPTION
The Github markdown preview was showing `KIP: 15` instead of `KIP: 17`.