### PR TITLE
documentation: kip-0017 remove extra array in example response

### DIFF
--- a/kip-0017.md
+++ b/kip-0017.md
@@ -233,54 +233,52 @@ This method returns the Kadena account names associated with a given [WalletConn
 {
   "id": 1,
   "jsonrpc": "2.0",
-  "result": [
-    {
-      "accounts": [
-        {
-          "account": "kadena:mainnet01:38298612cc2d5e841a232bd08413aa5304f9ef3251575ee182345abc3807dd89",
-          "publicKey": "38298612cc2d5e841a232bd08413aa5304f9ef3251575ee182345abc3807dd89",
-          "kadenaAccounts": [
-            {
-              "name": "w:aoriestnaoirsetnaorisetn",
-              "contract": "coin",
-              "chains": ["0", "1"]
-            },
-            {
-              "name": "bill",
-              "contract": "coin",
-              "chains": ["2", "4"]
-            },
-            {
-              "name": "k:38298612cc2d5e841a232bd08413aa5304f9ef3251575ee182345abc3807dd89",
-              "contract": "coin",
-              "chains": [
-                "0",
-                "1",
-                "2",
-                "3",
-                "4",
-                "5",
-                "6",
-                "7",
-                "8",
-                "9",
-                "10",
-                "11",
-                "12",
-                "13",
-                "14",
-                "15",
-                "16",
-                "17",
-                "18",
-                "19"
-              ]
-            }
-          ]
-        }
-      ]
-    }
-  ]
+  "result": {
+    "accounts": [
+      {
+        "account": "kadena:mainnet01:38298612cc2d5e841a232bd08413aa5304f9ef3251575ee182345abc3807dd89",
+        "publicKey": "38298612cc2d5e841a232bd08413aa5304f9ef3251575ee182345abc3807dd89",
+        "kadenaAccounts": [
+          {
+            "name": "w:aoriestnaoirsetnaorisetn",
+            "contract": "coin",
+            "chains": ["0", "1"]
+          },
+          {
+            "name": "bill",
+            "contract": "coin",
+            "chains": ["2", "4"]
+          },
+          {
+            "name": "k:38298612cc2d5e841a232bd08413aa5304f9ef3251575ee182345abc3807dd89",
+            "contract": "coin",
+            "chains": [
+              "0",
+              "1",
+              "2",
+              "3",
+              "4",
+              "5",
+              "6",
+              "7",
+              "8",
+              "9",
+              "10",
+              "11",
+              "12",
+              "13",
+              "14",
+              "15",
+              "16",
+              "17",
+              "18",
+              "19"
+            ]
+          }
+        ]
+      }
+    ]
+  }
 }
 ```
 


### PR DESCRIPTION
The original `kadena_getAccounts_v1` example response shows `{ result: [{ accounts: ...}]}` instead of the documented `{ result: { accounts: ... }}`. 

P.S. Koala wallet's implementation seems to be returning `{ result: { accounts: ... }}`