### PR TITLE
Create KIP-0023: Account management with Passkeys

### DIFF
--- a/kip-0023.md
+++ b/kip-0023.md
@@ -10,78 +10,148 @@ Created: 2023-10-27
 
 # Abstract
 
-We propose leveraging WebAuthn signatures as an alternative to ED25519
-signatures for creating passwordless accounts and approving transactions
-processed through Chainweb Node and Pact smart contracts.
+This document describes the proposal to leverage WebAuthn signatures as an
+alternative to ED25519 signatures, paving the way for users to create
+passwordless accounts and approve transactions without managing public and
+private keys. With this proposal, transactions from Pact smart contracts that
+are processed by Chainweb nodes can be signed with biometric authentication.
 
 # Motivation
 
 The current user experience for creating an account and signing transactions can
 be challenging for users unfamiliar with blockchain technology:
 
-- The concept of public / private keypairs is not widely understood.
-- Wallets often generate a 12-24 word mnemonic phrase that users need to store
-  securely in addition to a traditional password.
+- The concept of public and private key pairs is not widely understood.
+- Wallets often generate a 12 to 24 word mnemonic phrase that users need to
+  store securely in addition to a traditional password.
 
-Wallets access their private keys via software. This means that if the wallet is
-compromised, the user's key pairs can be used to sign without the user's
-awareness. With Kadena SpireKey you will always be prompted to personally sign
-for every transaction, which provides more security, transparency and control.
+People often underestimate the importance of keeping their private keys secure,
+and are likely to lose, mistype, or unintentionally expose them. Wallets also
+typically access private keys through software that, if compromised, might be
+used to sign transactions without a user's consent. With Kadena SpireKey and
+WebAuthn signatures, key pairs are stored directly on a secure enclave on the
+user's own devices. Storing keys in this way prevents the private key from being
+exposed or lost. In addition, Kadena SpireKey prompts users to sign for every
+transaction, providing greater security, transparency, and control.
 
-Mnemonic phrases are difficult to store securely and easy to lose. WebAuthn
-enables users to securely generate and store key pairs directly on their own
-hardware devices. There is no need to remember a mnemonic phrase. These key
-pairs can typically be accessed via Touch ID or Face ID, allowing users to log
-in and sign transactions without passwords. Since access is only granted using
-biometric authentication, the need for passwords is removed. Additionally, using
-WebAuthn key pairs provides a user-friendly and convenient experience similar to
-services like Apple Pay or Google Pay.
+Similarly, mnemonic phrases are difficult to store securely and easy to lose.
+With support for WebAuthn signatures, Kadena SpireKey enables users to securely
+generate and store key pairs directly on their own hardware devices, without
+needing to remember or store a mnemonic phrase. The key pairs stored on devices
+can typically be accessed using biometric authentication—like Touch ID or Face
+ID—allowing users to log in and sign transactions without passwords.
+Additionally, WebAuthn has a convienient service provided to sync the key pairs
+to the cloud, in the form of `Passkeys`. This service allows users to make use
+of any `Passkey Provider` of their choice, removing the reliance on big
+corporations to store key pairs.
 
 # Specifications
 
-## Webauthn Pact Keysets
+This section provides technical specifications for the implementation of this
+proposal.
 
-The WebAuthn public key that we provide to Chainweb Node is composed of a JSON
-Web Key (JWK) that has been base64 encoded and prefixed with `WEBAUTHN-`. The
-prefix indicates that different validation needs to be applied in Chainweb Node
-and Pact. This, however, should not impact any smart contracts as WebAuthn
-public keys are accepted as part of any keyset in Pact.
+## Account creation
+
+The `coin` contract removed the ability to rotate keysets since `v6`. This
+change protects users from front-running attacks and squatting attacks. To allow
+new devices to be added retroactively to an account, we need to use a principal
+type that allows keysets to be rotated. This new principal type is called the
+`r:account` principal.
+
+An `r:account` is created from a `keyset-ref-guard`. To protect users from
+front-running and squatting attacks, the `keyset-ref-guard` uses a
+`principal namespaces`. A `principal namespace` is created using a `keyset`, so
+that only the owner of that `keyset` can initialize the namespace on a chain.
+
+A keyset that is used to create the `principal namespace` is not intuitive and
+makes the onboarding more difficult. It's paramount to make sure the user has
+access to the keyset to initialize the namespace on new chains. For this reason,
+one `Passkey` is used as an entropy to create a hierarchical deterministic (HD)
+wallet. A second `Passkey` is created to be included in the keyset used to
+create the `principal namespace` and the `r:account`.
+
+For example:
 
 ```pact
 (env-data
   { 'ks :
     { 'keys :
-    ["WEBAUTHN-a50102032620012158206fb822acf87bea4a37c2d5ff067675456bd38afc4f3d43afd0c7d2c94cd997d6225820c464ff1bccf536172dea9eb37ae3bbfc411bf129afda751ea2f7faace4dbf9c8"]
-    , 'pred : 'keys-all
+      [ "WEBAUTHN-public-key"
+      , "ED25519-public-key-derived-from-HD-wallet-with-Passkey-entropy"
+      ]
+    , 'pred : 'keys-any
     }
   }
 )
-(enforce-keyset (read-keyset 'ks))
 ```
 
-### WebAuthn Keysets
+With the keyset composed of a HD wallet-derived public key and a Passkey, we can
+start the process of creating the `principal namespace` and `r:account`. To
+assist users maintaining their key pairs, we store the credential id's on chain
+in the `kadena.spirekey` contract. This contract allows wallets to keep track of
+the devices that are authorized to sign for transactions and allows the
+management of these devices to be decentralized.
 
-WebAuthn keysets are generated directly on the user's hardware device. This
-process involves creating a public/private key pair where the private key
-remains securely stored on the device, and the public key is shared with the
-service for authentication purposes.
+```pact
+(let* (
+  (ns-name (ns.create-principal-namespace (read-keyset 'ns-keyset)))
+  (ks-ref-name (format "{}.{}" [ns-name 'kadena]))
+)
+  (define-namespace
+    ns-name
+    (read-keyset 'ns-keyset )
+    (read-keyset 'ns-keyset )
+  )
+  (namespace ns-name)
+  (define-keyset ks-ref-name
+    (read-keyset 'ns-keyset)
+  )
+  (let (
+    (account (create-principal (keyset-ref-guard ks-ref-name)))
+  )
+    (coin.create-account
+      account
+      (keyset-ref-guard ks-ref-name)
+    )
+    (kadena.spirekey.add-device-pair
+      account
+      coin
+      { 'guard          :  (read-keyset 'spirekey-keyset) ; keyset of HD wallet derived public key and Passkey
+      , 'credential-id  :  "${credentialId}" ; Credential ID of the device
+      , 'domain         :  "${domain}" ; https://example.com
+      , 'device-type    :  "${deviceType}" ; AAGUID of the device or phone|desktop|security-key if not available
+      , 'color          :  "${color}" ; hex color of the device (optional for user to customize and further identify the device across different wallets)
+      }
+    )
+  )
+)
+```
 
-#### Cloud Backup
+## Transaction signing
 
-When generating keysets without cloud syncing, the private key never leaves the
-user's hardware device. For added convenience, backup and syncing can be enabled
-which involves encrypting the private key on the device before uploading it to a
-cloud service. Because the private key only leaves the device in its encrypted
-form, it remains secure even if the cloud storage is compromised.
+In most cases, users should use the Passkey for the `r:account` to sign
+transactions. This signing method is the most secure way to sign transactions.
+However, there are situations where it would be beneficial to use the HD
+wallet-derived public key to sign a transaction. For example, it might be
+beneficial to use the HD wallet-derived public key to sign transactions that
+perform account maintenance or prepare cross-chain operations for a dApp.
 
-Backing up your WebAuthn keysets to the cloud can be particularly useful if you
-lose your device, as the private key will still be accessible through your cloud
-provider, allowing you to restore access on a new device.
+Using a HD wallet-derived public key to sign for transactions is not as secure
+as using the Passkey. The HD wallet-derived public key is read into memory and,
+therefore, can be targeted by malware, similar to traditional wallets. The
+Passkey's private key is never read into memory and is, therefore, more secure.
 
-#### Retrieving the Public Key
+## Extracting a mnemonic phrase
 
-The JWK used to compose the public key for Pact keysets can be generated using
-the
+The Passkey used as entropy to create the HD wallet can also be used to extract
+the mnemonic phrase. The ability to extract a mnemonic phrase allows users to
+migrate to a traditional wallet if they wish to do so and to have another way to
+back up their wallet.
+
+## Retrieving Passkey information
+
+The JSON Web Key (JWK) used to compose the public key for Pact keysets can be
+generated using the
 [Web Authentication API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Authentication_API)
 on the browser using specific
 [configuration options](https://developer.mozilla.org/en-US/docs/Web/API/CredentialsContainer/create#publickey_object_structure)
@@ -89,21 +159,21 @@ to create an "account".
 
 Notes about specific configuration options:
 
-- `challenge`: When creating new credentials, a `challenge` will be requested by
-  the Web Authentication API. Since the creation of new credentials only
-  requires retrieval of the JWK and no signatures need to be created in the
-  process, the challenge value is arbitrary so we can provide any value that
-  satisfies the API.
-- `pubKeyCredParams`: Currently Chainweb Node only supports the `ES256`
-  encryption algorithm. This is represented by the algorithm value `-7`
+- `challenge`: When creating new credentials, the Web Authentication API
+  requests a `challenge` property to be provided. Because creating new
+  credentials only requires the retrieval of the JWK and no signatures need to
+  be created in the process, the challenge value is arbitrary and can be any
+  value that satisfies the API.
+- `pubKeyCredParams`: Currently, Chainweb nodes only support the `ES256`
+  encryption algorithm. This is represented by the algorithm value `-7`.
 - `user`: The user requires an `id` which needs to be unique for every account.
   If a new account is created using the same `id` as an existing account, the
   former account will be overwritten and lost. It is best to ensure that this
   `id` is unique, otherwise you may not be able to access assets guarded by the
   Pact keyset derived from the lost account.
 - `rp`: rp stands for `relying party` and will default to the document origin
-  when it is omitted. This is provided because webauthn keys are always tied to
-  a specific domain and cannot be used with any other domains
+  when it is omitted. This is provided because WebAuthn keys are always tied to
+  a specific domain and cannot be used with any other domains.
 
 ```js
 var publicKeyConfig = {
@@ -140,27 +210,54 @@ var publicKeyConfig = {
 };
 ```
 
-## Chainweb Node Requests
+The response from the Web Authentication API contains the `credentialId` and the
+`publicKey` that can be used to create a keyset for the `r:account`.
 
-When using WebAuthn to sign for transactions, Chainweb Node requires some
-additional information to validate signatures.
+```json
+{
+  "id": "credentialId",
+  "type": "public-key",
+  "rawId": "Uint8Array",
+  "response": {
+    "clientDataJSON": "Uint8Array",
+    "attestationObject": "Uint8Array"
+  },
+  "clientExtensionResults": {}
+}
+```
+
+The AAGUID for a device is a 16 byte value that is unique to the device. This
+identifier can be used to identify the device and show the user the Passkey
+provider that's used to store the key pairs. The AAGUID can be retrieved from
+the `attestationObject` in the response from the Web Authentication API. For
+more information about the AAGUID, see the following articles:
+
+- [Determine Passkey with AAGUID](https://web.dev/articles/webauthn-aaguid)
+- [AAGUID Mapping](https://github.com/passkeydeveloper/passkey-authenticator-aaguids)
+
+## Chainweb node requests
+
+When using WebAuthn to sign for transactions, Chainweb nodes require some
+additional information to validate the signatures.
 
 > In the below json schema's the new or updated attributes are prefixed with a
 > `+`.
 
-### Sigs Payload
+### Sigs payload
 
 `ED25519` signatures are generated by signing the transaction `hash` using the
-private key which Chainweb Node can validate using the public key.
+private key that Chainweb node can validate using the public key.
 
-When using WebAuthn signatures, the authenticator (the hardware device used to
-generate the keyset and sign for transactions) will sign a message constructed
-using `authenticatorData` and `clientDataJSON`. In order to validate the
-signature, this data will need to be provided along with the signature to
-Chainweb Node.
+When using WebAuthn signatures, the authenticator—that is, the hardware device
+used to generate the keyset and sign for transactions—signs a message
+constructed using `authenticatorData` and `clientDataJSON`. To validate the
+signature, this data needs to be provided along with the signature to the
+Chainweb node.
 
-To do this, you will first need to create a JSON object of the `signature`,
-`authneticatorData`, and `clientDataJSON`.
+To validate the signature:
+
+1. Create a JSON object with the `signature`, `authneticatorData`, and
+   `clientDataJSON`.
 
 ```json
 {
@@ -170,8 +267,7 @@ To do this, you will first need to create a JSON object of the `signature`,
 }
 ```
 
-You will then need to stringify this object and pass it to the `sig` field in
-the transaction.
+2. Stringify this object and pass it to the `sig` field in the transaction.
 
 ```json
 {
@@ -183,11 +279,11 @@ the transaction.
 }
 ```
 
-### Command Payload
+### Command payload
 
-In the command payload the `signers` array provides information about the public
-key(s) that will be signing the request. The `scheme` should indicate that the
-signature will be provided via `WebAuthn`.
+In the command payload, the `signers` array provides information about the
+public key(s) that are signing the request. The `scheme` should indicate that
+the signature provided is `WebAuthn`.
 
 ```json
 {
@@ -218,48 +314,6 @@ signature will be provided via `WebAuthn`.
 }
 ```
 
-## R:Accounts
-
-Principal accounts don't allow keysets to be rotated. However there exists one
-principal type that facilitates this behavior, the `r:account`. An `r:account`
-is created from a `keyset-ref-guard`. To protect such keyset, users should only
-create referenced keysets on a `principal namespace`.
-
-### Principal namespace
-
-A principal namespace is created using a `keyset`, ensuring only the owner of
-that `keyset` to initialize that namespace on a chain. Initializing such keyset
-is not an intuitive process and makes the onboarding more difficult.
-
-To combat this we propose to use a `temporary keypair` to be part of the keyset
-to create the `principal namespace` and `r:account`. The wallet will be able to
-sign using the `temporary keypair` to authorize the transaction to create both
-the `principal namespace` as well as the `r:account`. This way the user does not
-need to sign for this initialization for each chain, preventing a tedious
-repetition of performing the biometric authentication for each chain.
-
-The `temporary keypair` should be removed and forgotten after creation of the
-account. The attack vector is therefor similar to traditional wallets during
-account and namespace creation and after the creation will be more secure as
-there will be no more `private keys` involved with authorizing these assets.
-
-### WebAuthn Credential Ids
-
-To sign for a transaction the wallet needs to initialize the transaction using
-the credential id paired with the keypair. Therefor the wallet needs to keep
-track of what credential id belongs to what public key. This can be stored
-in traditional wallets, but we propose to also store this information on chain
-to ease the process of transitioning wallets.
-
-The credential information will be stored in `spirekey.pact` allowing users
-to keep track of what credential id's belong to their `r:account`.
-
-#### Registering an existing account with a new wallet
-
-Accounts guarded by a `r:account` can rotate their keyset using any keypair.
-This includes traditional wallets or hardware wallets. Wallets have to prepare
-the keyset to be modified and rotated into the `r:account`.
-
 ## Registration flow
 
 ```mermaid
@@ -271,12 +325,21 @@ sequenceDiagram
   participant Fungible(SC)
   participant SpireKey(SC)
 
-  User->>+WalletA.com: I'd like to create an account named "Alice"
-  WalletA.com->>+WebAuthn(Device): Please give me a public key for Alice
+  User->>+WalletA.com: I'd like to create a account
+  WalletA.com-->>-User: You don't have a wallet yet, create one?
+  User->>+WalletA.com: Yes, I'd like to create a wallet
+  WalletA.com->>+WebAuthn(Device): Please give me a passkey
   WebAuthn(Device)->>+User: Please approve this request
   User-->>-WebAuthn(Device): I approve this request
-  WebAuthn(Device)-->>-WalletA.com: Here is the public key: abc000
-  WalletA.com->>-WalletA.com: Generate Temporary Keypair
+  WebAuthn(Device)-->>-WalletA.com: Here is the passkey
+  WalletA.com->>-WalletA.com: Generate HD wallet with Passkey
+  WalletA.com-->>User: We've created a wallet, continue to create an account?
+  User->>+WalletA.com: Yes, I'd like to create an account
+  WalletA.com->>+WebAuthn(Device): Please give me a passkey
+  WebAuthn(Device)->>+User: Please approve this request
+  User-->>-WebAuthn(Device): I approve this request
+  WebAuthn(Device)-->>-WalletA.com: Here is the passkey
+  WalletA.com->>-WalletA.com: Construct keyset
   WalletA.com->>+Chainweb: Register `n_abc` namespace
   WalletA.com->>+Fungible(SC): Register `r:account`
   WalletA.com->>+SpireKey(SC): Register credential id with `r:account`
@@ -295,20 +358,22 @@ sequenceDiagram
   User->>+dApp: Hi I'm "Alice"
   dApp-->>-User: What wallet would like to use to identify yourself with?
   User->>+dApp: I'd like to use WalletA.com
-  dApp-->>-WalletA.com: Please provide me account information
+  dApp->>+WalletA.com: Please provide me account information
   WalletA.com-->>+User: Which account would you like to use?
   User->>-WalletA.com: Please use this `r:account`
-  WalletA.com-->>+dApp: Here are the details
+  WalletA.com-->>-dApp: Here are the details
   User->>+dApp: I'd like to buy this product
-  dApp-->>-User: Here is the transaction to order the product
-  User->>+WalletA.com: Please sign for this transaction
+  dApp->>+WalletA.com: Here is the transaction to order the product
+  WalletA.com->>+User: Do you approve this transaction?
+  User-->>-WalletA.com: Yes, I approve this transaction
   WalletA.com->>+WebAuthn(Device): Please provide the signature for this txhash
-  WalletA.com-->>-User: Here is the tx with signature
-  User->>+dApp: Here is the tx with signature
+  WebAuthn(Device)->>-WalletA.com: Here is the signature
+  WalletA.com-->>-dApp: Here is the tx with signature
   dApp->>+Chainweb: Submitting tx
+  dApp-->>-User: Tx submitted
 ```
 
-## Sign flow Traditional Wallet
+## Signing flow for a traditional wallet
 
 ```mermaid
 flowchart TB
@@ -336,7 +401,7 @@ SE/TEE -- Send Authentication Signature --> Wallet
 Wallet -- Send Transaction Signature --> Chainweb
 ```
 
-## Sign flow WebAuthn Wallet
+## Signing flow for a WebAuthn wallet
 
 ```mermaid
 flowchart TB

--- a/kip-0023.md
+++ b/kip-0023.md
@@ -1,0 +1,208 @@
+---
+KIP: "0023"
+Title: WebAuthn signatures for Chainweb and Pact
+Author: Andy Tang @EnoF
+Status: Draft
+Type: Standard
+Category: Interface
+Created: 2023-10-27
+---
+
+# Abstract
+
+We propose to use WebAuthn signatures as an alternative option to the current
+ED25519 signatures to allow users to approve for transactions processed through
+Chainweb Node and Pact smart contracts.
+
+# Motivation
+
+WebAuthn allows for users to use a hardware powered device to store keypairs securely.
+Users will be able to interact with those stored keypairs only by initiating a sign
+request from the registered web domain. The private key never leaves the device
+and the user never enters a password. This brings the user more security and convenience
+simultaneously.
+
+In comparison to current wallets, the wallet developers have no access to the
+private keys. The user does not have to write down their mnemonics or even enter
+their password to decrypt their privatekeys.
+
+# Specifications
+
+## Schema Sketch
+
+In the below json schema's the new or updated attributes are prefixed with a `+`
+
+### Chainweb Node Request
+
+A WebAuthn sign request is slightly different than a usual signature. The authenticator
+signing the request appends on the `challenge` additional data. For our `ED25519` signatures
+we use the private key to sign for the `hash` as message. WebAuthn attaches the
+`authenticatorData` and `clientDataJSON` to the message before signing. That data
+will be provided along with the signature.
+
+In order to verify the signature you therefore need to first reconstruct the message
+using the `hash`, `authenticatorData` and `clientDataJSON`.
+
+```json
+{
+  "cmd": string,
+  "hash": string,
+  "sigs": [
+    {
+      "sig": string,
++     "authenticatorData": string,
++     "clientDataJSON": string,
+    }
+  ]
+}
+```
+
+### Command Payload
+
+In the command payload the `signers` array provides information about the
+public key that will be signing for this request. The `scheme` should
+indicate that the signature will be provided via `WebAuthn`.
+
+The public key should be described in base64 encoded `JWK` format. This
+allows for greater flexibility in the future when Chainweb Node decides to
+accept more algorithms. The `JWK` format allows for the clients constructing
+the request to remain blissfully unaware of what algorithm is used by the
+authenticator.
+
+_NOTE: Additionally Chainweb Node could provide a new endpoint that describes which_
+_algorithms to support, using the [Allow credentials](https://www.w3.org/TR/webauthn-2/#dom-publickeycredentialrequestoptions-allowcredentials)_
+_description._
+
+```json
+{
+  "payload": {
+    "exec": {
+      "code": string,
+      "data": json
+    },
+  },
+  "meta": {
+    "chainId": string,
+    "creationTime": number,
+    "gasLimit": number,
+    "gasPrice": number,
+    "sender": string,
+    "ttl": number
+  },
+  "networkId": string,
+  "nonce": string,
+  "signers": [{
+    "clist": [{
+      "name": string,
+      "args": [string|number]
+    }],
++   "pubKey": string,
++   "scheme": "ED25519" | "WebAuthn"
+  }]
+}
+```
+
+### Pact Keyset
+
+In Pact the public key should be accepted as part of any keyset.
+This allows Smart Contracts to use the registered keysets as any other
+keyset. This should not be impacting any smart contracts, other than
+more types of public keys being accepted.
+
+_NOTE: A keyset using such a base64 encoded public key might exceed_
+_the current limitations of a principaled acount length for newer algorithms_
+
+```pact
+(env-data
+  { 'ks :
+    { 'keys :
+    ["eyJrdHkiOiJFQyIsImFsZyI6IkVTMjU2IiwiY3J2IjoiUC0yNTYiLCJ4IjoiNy02UHRXYmxhNUdUSTJaZ3VpTU43UXhaTmZKQXlXTzAzTDRaUHVoSG5ydyIsInkiOiI0UlVuOU54eWRUdU5DOTR5YWx6RUV4c2pianJsVy1xbkV4REg0emM3aUIwIn0"]
+    , 'pred : 'keys-all
+    }
+  }
+)
+(enforce-keyset (read-keyset 'ks))
+```
+
+## Registration flow
+
+```mermaid
+sequenceDiagram
+  actor User
+  participant WebAuthn(Device)
+  participant WalletA.com
+  participant WebAuthn(SC)
+  participant Fungible(SC)
+
+  User->>+WalletA.com: I'd like to create an account named "Alice"
+  WalletA.com->>+WebAuthn(SC): What is the "c:account" for "Alice"?
+  WebAuthn(SC)-->>-WalletA.com: That would be "c:capabilityguardforalice"
+  WalletA.com->>+WebAuthn(Device): Please give me a public key for Alice, c:capabilityguardforalice
+  WebAuthn(Device)->>+User: Please approve this request
+  User-->>-WebAuthn(Device): I approve this request
+  WebAuthn(Device)-->>-WalletA.com: Here is the public key: abc000
+  WalletA.com->>+WebAuthn(Device): Here is the transaction to register, please sign
+  WebAuthn(Device)->>+User: Please approve this transaction
+  User-->>-WebAuthn(Device): I approve this transaction
+  WebAuthn(Device)-->>-WalletA.com: Here is the signature for the transaction
+  WalletA.com->>+WebAuthn(SC): Please register "Alice" with this public key
+  WebAuthn(SC)->>+Fungible(SC): Create an account for "c:capabilityguardforalice"
+```
+
+## Registration flow (second wallet)
+
+```mermaid
+sequenceDiagram
+  actor User
+  participant WebAuthn(Device)
+  participant WalletA.com
+  participant WalletB.com
+  participant WebAuthn(SC)
+
+  User->>+WalletB.com: I'd like to add this wallet to my existing account "Alice"
+  WalletB.com->>+WebAuthn(SC): What is the public key of the previously registered device for "Alice"?
+  WebAuthn(SC)-->>-WalletB.com: That would be "abc000"
+  Note right of WalletB.com: Public key is needed to construct the transaction
+  WalletB.com->>+WebAuthn(Device): Please give me a public key for Alice, c:capabilityguardforalice
+  Note right of WalletB.com: The public key will be different from the public key provided to WalletA.com
+  WebAuthn(Device)->>+User: Please approve this request
+  User-->>-WebAuthn(Device): I approve this request
+  WebAuthn(Device)-->>-WalletB.com: Here is the public key: fff000
+  WalletB.com->>+WebAuthn(Device): Here is the transaction to register, please sign
+  WebAuthn(Device)->>+User: Please approve this transaction
+  User-->>-WebAuthn(Device): I approve this transaction
+  WebAuthn(Device)-->>-WalletB.com: Here is the signature for the transaction
+  WalletB.com->>+WalletA.com: Please approve this registration
+  WalletA.com->>+User: WalletB wants to register for "Alice", do you wish to proceed?
+  User->>-WalletA.com: I would like to proceed
+  WalletA.com->>+WebAuthn(Device): Here is the transaction to register, please sign
+  WebAuthn(Device)->>+User: Please approve this transaction
+  User-->>-WebAuthn(Device): I approve this transaction
+  WalletA.com->>+WebAuthn(SC): Please add WalletB.com as wallet for this account
+```
+
+## Sign for transaction (dApp)
+
+```mermaid
+sequenceDiagram
+  actor User
+  participant WebAuthn(Device)
+  participant dApp
+  participant WalletA.com
+  participant Chainweb
+
+  User->>+dApp: Hi I'm "Alice"
+  dApp-->>-User: What wallet would like to use to identify yourself with?
+  User->>+dApp: I'd like to use WalletA.com
+  dApp-->>-User: Please provide me account information
+  User->>+WalletA.com: Please provide my account info
+  WalletA.com-->>-User: Here is your info: abc00, c:capabilityguardforalice
+  User->>+dApp: Here are my details
+  User->>+dApp: I'd like to buy this product
+  dApp-->>-User: Here is the transaction to order the product
+  User->>+WalletA.com: Please sign for this transaction
+  WalletA.com->>+WebAuthn(Device): Please provide the signature for this txhash
+  WalletA.com-->>-User: Here is the tx with signature
+  User->>+dApp: Here is the tx with signature
+  dApp->>+Chainweb: Submitting tx
+```

--- a/kip-0023.md
+++ b/kip-0023.md
@@ -1,7 +1,7 @@
 ---
 KIP: "0023"
 Title: WebAuthn signatures for Chainweb and Pact
-Author: Andy Tang @EnoF
+Author: Andy Tang @EnoF, Eileen Guo @eileenmguo
 Status: Draft
 Type: Standard
 Category: Interface
@@ -10,68 +10,183 @@ Created: 2023-10-27
 
 # Abstract
 
-We propose to use WebAuthn signatures as an alternative option to the current
-ED25519 signatures to allow users to approve for transactions processed through
-Chainweb Node and Pact smart contracts.
+We propose leveraging WebAuthn signatures as an alternative to ED25519
+signatures for creating passwordless accounts and approving transactions
+processed through Chainweb Node and Pact smart contracts.
 
 # Motivation
 
-WebAuthn allows for users to use a hardware powered device to store keypairs
-securely. Users will be able to interact with those stored keypairs only by
-initiating a sign request from the registered web domain. The private key never
-leaves the device and the user never enters a password. This brings the user
-more security and convenience simultaneously.
+The current user experience for creating an account and signing transactions can
+be challenging for users unfamiliar with blockchain technology:
 
-In comparison to current wallets, the wallet developers have no access to the
-private keys. The user does not have to write down their mnemonics or even enter
-their password to decrypt their privatekeys.
+- The concept of public / private keypairs is not widely understood.
+- Wallets often generate a 12-24 word mnemonic phrase that users need to store
+  securely in addition to a traditional password.
+
+Moreover, the security of accounts generated through many existing wallets is
+centralized because the user's key pairs are generated and stored by the wallet
+provider. If the wallet provider becomes unavailable or is compromised, users
+may lose access to their assets.
+
+WebAuthn enables users to securely generate and store key pairs directly on
+their own hardware devices. These key pairs can typically be accessed via Touch
+ID or Face ID, allowing users to log in and sign transactions without passwords.
+Since the private key is stored on the user's hardware device and there is no
+need for storing a password, this method enhances security. Additionally, using
+WebAuthn key pairs provides a user-friendly and convenient experience similar to
+services like Apple Pay or Google Pay.
 
 # Specifications
 
-## Schema Sketch
+## Webauthn Pact Keysets
 
-In the below json schema's the new or updated attributes are prefixed with a `+`
+The WebAuthn public key that we provide to Chainweb Node is composed of a JSON
+Web Key (JWK) that has been base64 encoded and prefixed with `WEBAUTHN-`. The
+prefix indicates that different validation needs to be applied in Chainweb Node
+and Pact. This, however, should not impact any smart contracts as WebAuthn
+public keys are accepted as part of any keyset in Pact.
 
-### Chainweb Node Request
+```pact
+(env-data
+  { 'ks :
+    { 'keys :
+    ["WEBAUTHN-a50102032620012158206fb822acf87bea4a37c2d5ff067675456bd38afc4f3d43afd0c7d2c94cd997d6225820c464ff1bccf536172dea9eb37ae3bbfc411bf129afda751ea2f7faace4dbf9c8"]
+    , 'pred : 'keys-all
+    }
+  }
+)
+(enforce-keyset (read-keyset 'ks))
+```
 
-A WebAuthn sign request is slightly different than a usual signature. The
-authenticator signing the request appends on the `challenge` additional data.
-For our `ED25519` signatures we use the private key to sign for the `hash` as
-message. WebAuthn attaches the `authenticatorData` and `clientDataJSON` to the
-message before signing. That data will be provided along with the signature.
+### WebAuthn Keysets
 
-In order to verify the signature you therefore need to first reconstruct the
-message using the `hash`, `authenticatorData` and `clientDataJSON`.
+WebAuthn keysets are generated directly on the user's hardware device. This
+process involves creating a public/private key pair where the private key
+remains securely stored on the device, and the public key is shared with the
+service for authentication purposes.
+
+#### Cloud Backup
+
+When generating keysets without cloud syncing, the private key never leaves the
+user's hardware device. For added convenience, backup and syncing can be enabled
+which involves encrypting the private key on the device before uploading it to a
+cloud service. Because the private key only leaves the device in its encrypted
+form, it remains secure even if the cloud storage is compromised.
+
+Backing up your WebAuthn keysets to the cloud can be particularly useful if you
+lose your device, as the private key will still be accessible through your cloud
+provider, allowing you to restore access on a new device.
+
+#### Retrieving the Public Key
+
+The JWK used to compose the public key for Pact keysets can be generated using
+the
+[Web Authentication API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Authentication_API)
+on the browser using specific
+[configuration options](https://developer.mozilla.org/en-US/docs/Web/API/CredentialsContainer/create#publickey_object_structure)
+to create an "account".
+
+Notes about specific configuration options:
+
+- `challenge`: When creating new credentials, a `challenge` will be requested by
+  the Web Authentication API. Since the creation of new credentials only
+  requires retrieval of the JWK and no signatures need to be created in the
+  process, the challenge value is arbitrary so we can provide any value that
+  satisfies the API.
+- `pubKeyCredParams`: Currently Chainweb Node only supports the `ES256`
+  encryption algorithm. This is represented by the algorithm value `-7`
+- `user`: The user requires an `id` which needs to be unique for every account.
+  If a new account is created using the same `id` as an existing account, the
+  former account will be overwritten and lost. It is best to ensure that this
+  `id` is unique, otherwise you may not be able to access assets guarded by the
+  Pact keyset derived from the lost account.
+- `rp`: rp stands for `relying party` and will default to the document origin
+  when it is omitted. This is provided because webauthn keys are always tied to
+  a specific domain and cannot be used with any other domains
+
+```js
+var publicKeyConfig = {
+  challenge: Uint8Array.from("arbitrary-string"),
+
+  // Relying Party:
+  rp: {
+    name: 'Kadena SpireKey',
+    id: window.location.hostname, // defaults to the document origin when omitted
+  },
+
+  user: {
+    id: Uint8Array.from("Alex Müller" + Date.now())
+    name: 'alex.mueller@example.com',
+    displayName: 'Alex Müller',
+  },
+
+  // This Relying Party will accept an ES256 credential
+  pubKeyCredParams: [
+    {
+      type: 'public-key',
+      alg: -7, // "ES256" as registered in the IANA COSE Algorithms registry
+    },
+  ],
+
+  authenticatorSelection: {
+    // Try to use UV if possible. This is also the default.
+    userVerification: 'preferred',
+  },
+
+  timeout: 60000, // 1 minute
+
+  attestation: "direct" // Retrieves the attestation statement as generated by the authenticator
+};
+```
+
+## Chainweb Node Requests
+
+When using WebAuthn to sign for transactions, Chainweb Node requires some
+additional information to validate signatures.
+
+> In the below json schema's the new or updated attributes are prefixed with a
+> `+`.
+
+### Sigs Payload
+
+`ED25519` signatures are generated by signing the transaction `hash` using the
+private key which Chainweb Node can validate using the public key.
+
+When using WebAuthn signatures, the authenticator (the hardware device used to
+generate the keyset and sign for transactions) will sign a message constructed
+using `authenticatorData` and `clientDataJSON`. In order to validate the
+signature, this data will need to be provided along with the signature to
+Chainweb Node.
+
+To do this, you will first need to create a JSON object of the `signature`,
+`authneticatorData`, and `clientDataJSON`.
+
+```json
+{
++ "signature": string,
++ "authenticatorData": string,
++ "clientDataJSON": string,
+}
+```
+
+You will then need to stringify this object and pass it to the `sig` field in
+the transaction.
 
 ```json
 {
   "cmd": string,
   "hash": string,
-  "sigs": [
-    {
-      "sig": string,
-+     "authenticatorData": string,
-+     "clientDataJSON": string,
-    }
-  ]
+  "sigs": [{
++   "sig": string // Stringified JSON
+  }],
 }
 ```
 
 ### Command Payload
 
 In the command payload the `signers` array provides information about the public
-key that will be signing for this request. The `scheme` should indicate that the
+key(s) that will be signing the request. The `scheme` should indicate that the
 signature will be provided via `WebAuthn`.
-
-The public key should be described in base64 encoded `JWK` format. This allows
-for greater flexibility in the future when Chainweb Node decides to accept more
-algorithms. The `JWK` format allows for the clients constructing the request to
-remain blissfully unaware of what algorithm is used by the authenticator.
-
-_NOTE: Additionally Chainweb Node could provide a new endpoint that describes
-which_ _algorithms to support, using the
-[Allow credentials](https://www.w3.org/TR/webauthn-2/#dom-publickeycredentialrequestoptions-allowcredentials)_
-_description._
 
 ```json
 {
@@ -102,41 +217,29 @@ _description._
 }
 ```
 
-### Pact Keyset
-
-In Pact the public key should be accepted as part of any keyset. This allows
-Smart Contracts to use the registered keysets as any other keyset. This should
-not be impacting any smart contracts, other than more types of public keys being
-accepted. The WebAuthn key will be prefixed with `WEBAUTHN-` to allow different
-validations to be applied on the keys in `Chainweb Node` and `Pact`.
-
-```pact
-(env-data
-  { 'ks :
-    { 'keys :
-    ["WEBAUTHN-a50102032620012158206fb822acf87bea4a37c2d5ff067675456bd38afc4f3d43afd0c7d2c94cd997d6225820c464ff1bccf536172dea9eb37ae3bbfc411bf129afda751ea2f7faace4dbf9c8"]
-    , 'pred : 'keys-all
-    }
-  }
-)
-(enforce-keyset (read-keyset 'ks))
-```
-
 ## WebAuthn Smart Contracts
 
 In order to manage accounts guarded by a `WebAuthn` key, two new smart contracts
-will be introduced. This is done to put a thin layer of abstraction on top of
-the keysets and allow an account to be able to have multiple devices attached in
-retrospect. This way an account is not limited to the devices known during
-registration, but keeps the ability to add more or rotate devices out of the
-guard.
+will be introduced: `webauthn-guard` and `webauthn-wallet`.
+
+This approach creates a thin layer of abstraction over the keysets, enabling an
+account to have multiple devices associated with it. As a result, an account is
+not restricted to the devices known at the time of registration, but retains the
+flexibility to add new devices or replace existing ones.
 
 ### WebAuthn Guard Smart Contract
 
-This smart contract is managing an account that keeps track of all keys tied to
-this account. It also allows for a user to define how many keys needs to sign
-for authorization requests and registration requests separately. The schema
-looks like:
+The `webauthn-guard` contract handles account management and authorization. It
+keeps track of all the keysets associated with an account and allows users to
+configure how many keysets need to sign for authorization and additional keyset
+registration requests.
+
+> This account architecture takes inspiration from how keysets work in Pact. For
+> example, a webauthn guard is like a multi-key keyset with a minimum approval
+> predicate, however it allows for adding additional keys in retrospect and
+> there can be custom minimum approval requirements for adding new keys.
+
+The following is a snippet of the account schema from `webauthn-guard`:
 
 ```pact
 (defschema device-schema
@@ -145,9 +248,11 @@ looks like:
   credential-id : string
   guard         : guard
 )
+
 (defschema account-schema
   @model [
     (invariant (> (length devices) 0))
+    (invariant (< (length devices) 5))
     (invariant (> min-approvals 0))
     (invariant (> min-registration-approvals 0))
     (invariant (<= min-approvals (length devices)))
@@ -159,54 +264,76 @@ looks like:
 )
 ```
 
-The id of the account is derived from the keyset defined in the first
-registration device. This will result in a `w:account`. With this device the
-account can be created on any chain and will always result in the same
-`w:account`.
+> Note: `device` refers to a webauthn keyset in this context, however any keyset
+> can be used as a `device`. (I think we should update it to keyset?)
 
-In the event where the first device has been lost, a user can make use of a copy
-function. The copy function will perform a `defpact` where the account state of
-any given chain will be copied over to a new chain. The user will have to sign
-with enough keys to satisfy the amount of keys defined with the
-`min-registration-approvals` setting.
+The `id` for each `webauthn-guard` account is derived from the principal of the
+keyset used to create the account. When the principal is created from the
+keyset, Pact identifies the keyset as being of the WebAuthn type and generates a
+`w:account`. Given the uniqueness of all WebAuthn keysets, only the person with
+access to the original account should be able to access the same `w:account` on
+other chains.
+
+To create the same account on different chains, we recommend using the `copy`
+function. This function recreates the account in its current state on another
+chains by executing a defpact to transfer the current `account-schema` to the
+new chain. This process acts like a new registration and requires the user to
+meet the `min-registration-approval` criteria.
+
+#### Registering an existing account with a new wallet
+
+Accounts created with the `webauthn-guard` contract can be accessed through
+multiple wallets. Although WebAuthn keysets are domain-specific (i.e., users can
+only sign transactions with the keysets generated on their original wallet),
+additional keysets from another wallet can be added if the registration
+requirements are met with the original wallet's keysets. This provides users
+with greater flexibility in choosing wallets and reduces dependence on any
+single wallet.
 
 ### WebAuthn Wallet Smart Contract
 
-This smart contract is a thin wrapper around the `WebAuthn Guard` contract and
-`fungible-v2` contract references. Based on the `w:account` created in the
-`WebAuthn Guard` contract a new `c:account` will be created in the
-`WebAuthn Wallet` contract. The capability to guard the `fungible-v2` accounts
-will inherit the principal properties from the `WebAuthn Guard` account and make
-sure that account ownership is protected using the same mechanism.
+The `webauthn-wallet` contract is designed to facilitate the integration of
+webauthn-guard accounts with existing `fungible-v2` contracts.
 
-#### WebAuthn Wallet Capabilities
+To create a `fungible-v2` account, you need to provide an account name and a
+guard. Since Pact accepts capabilities as guards, `webauthn-wallet` performs the
+following steps:
 
-The `WebAuthn Wallet` capablities will guard the actions of the account. The
-main capability to guard the account is based on: `DEBIT`. This capability has
-the `w:account` as parameter. To make sure end users are not required to
-understand all the concepts, we have split the capabilities they will sign for.
-Those capabilities will provide an abstraction on top of the `w:account`.
+- Creates a capability guard using the `w:account` from `webauthn-guard`
+- Uses the `c:account` as the guard for the `fungible-v2` account
 
-Users will be presented with the `TRANSFER` capability. This capability will
-expect the user's `c:account` the `account` of the receiver known in the
-`fungible-v2` contract and the `amount` to transfer. So the capability to sign
-would look like:
+By employing a capability guard, we are able to enforce the requirements of the
+`webauthn-guard` account and use the associated keysets to secure the
+`fungible-v2` account.
 
-```pact
-(n_56...bc.webauthn-wallet.TRANSFER "c:LR1...Dx0" "any-account" 1.0)
-```
+#### Account Management
 
-Additionally the `WebAuthn Wallet` contract will provide for some easy wrappers
-around management functions of the `WebAuthn Guard` contract. This way the end
-users can manage their `WebAuthn Guard` without the burden of knowing the
-`w:account` and all they need to keep track of is the `c:account`
-
-The `WebAuthn Wallet` will wrap the following functions from the
-`WebAuthn Guard`:
+Each `webauthn-wallet` account has a `w:account` that is used as the identifier
+for the `webauthn-guard` and a `c:account` which is used for the `fungible-v2`.
+To simplify account management, `webauthn-wallet` wraps some functions, allowing
+users to only track their `c:account`. The following functions from
+`webauthn-guard` are wrapped by `webauthn-wallet`:
 
 - add-device
 - remove-device
 - copy-account
+
+#### WebAuthn Wallet Capabilities
+
+Since `fungible-v2` accounts are guarded by a capability, transactions requiring
+authentication must bring in `webauthn-wallet` capabilities into scope.
+
+Most contracts should be written with `webauthn-guard` and `webauthn-wallet` in
+mind. However, the `coin` contract, being non-upgradable, will likely not
+accommodate `webauthn-wallet` accounts. As a result, you cannot bring the
+`webauthn-wallet.DEBIT` capability into scope when using native `coin`
+functions/capabilities. To address this, the `webauthn-wallet` contract provides
+the following functions/capabilities as alternatives to their `coin`
+counterparts:
+
+- `coin.transfer` _(function)_ -> `webauthn-wallet.transfer`
+- `coin.GAS` _(capability)_ -> `webauthn-wallet.GAS_PAYER`
+- `coin.TRANSFER` _(capability)_ -> `webauthn-wallet.TRANSFER`
 
 ## Registration flow
 
@@ -219,50 +346,18 @@ sequenceDiagram
   participant Fungible(SC)
 
   User->>+WalletA.com: I'd like to create an account named "Alice"
-  WalletA.com->>+WebAuthn(SC): What is the "c:account" for "Alice"?
-  WebAuthn(SC)-->>-WalletA.com: That would be "c:capabilityguardforalice"
   WalletA.com->>+WebAuthn(Device): Please give me a public key for Alice, c:capabilityguardforalice
   WebAuthn(Device)->>+User: Please approve this request
   User-->>-WebAuthn(Device): I approve this request
   WebAuthn(Device)-->>-WalletA.com: Here is the public key: abc000
+  WalletA.com->>+WebAuthn(SC): What is the "c:account" for "Alice"?
+  WebAuthn(SC)-->>-WalletA.com: That would be "c:capabilityguardforalice"
   WalletA.com->>+WebAuthn(Device): Here is the transaction to register, please sign
   WebAuthn(Device)->>+User: Please approve this transaction
   User-->>-WebAuthn(Device): I approve this transaction
   WebAuthn(Device)-->>-WalletA.com: Here is the signature for the transaction
   WalletA.com->>+WebAuthn(SC): Please register "Alice" with this public key
   WebAuthn(SC)->>+Fungible(SC): Create an account for "c:capabilityguardforalice"
-```
-
-## Registration flow (second wallet)
-
-```mermaid
-sequenceDiagram
-  actor User
-  participant WebAuthn(Device)
-  participant WalletA.com
-  participant WalletB.com
-  participant WebAuthn(SC)
-
-  User->>+WalletB.com: I'd like to add this wallet to my existing account "Alice"
-  WalletB.com->>+WebAuthn(SC): What is the public key of the previously registered device for "Alice"?
-  WebAuthn(SC)-->>-WalletB.com: That would be "abc000"
-  Note right of WalletB.com: Public key is needed to construct the transaction
-  WalletB.com->>+WebAuthn(Device): Please give me a public key for Alice, c:capabilityguardforalice
-  Note right of WalletB.com: The public key will be different from the public key provided to WalletA.com
-  WebAuthn(Device)->>+User: Please approve this request
-  User-->>-WebAuthn(Device): I approve this request
-  WebAuthn(Device)-->>-WalletB.com: Here is the public key: fff000
-  WalletB.com->>+WebAuthn(Device): Here is the transaction to register, please sign
-  WebAuthn(Device)->>+User: Please approve this transaction
-  User-->>-WebAuthn(Device): I approve this transaction
-  WebAuthn(Device)-->>-WalletB.com: Here is the signature for the transaction
-  WalletB.com->>+WalletA.com: Please approve this registration
-  WalletA.com->>+User: WalletB wants to register for "Alice", do you wish to proceed?
-  User->>-WalletA.com: I would like to proceed
-  WalletA.com->>+WebAuthn(Device): Here is the transaction to register, please sign
-  WebAuthn(Device)->>+User: Please approve this transaction
-  User-->>-WebAuthn(Device): I approve this transaction
-  WalletA.com->>+WebAuthn(SC): Please add WalletB.com as wallet for this account
 ```
 
 ## Sign for transaction (dApp)

--- a/kip-0023.md
+++ b/kip-0023.md
@@ -52,7 +52,7 @@ proposal.
 
 ## Account creation
 
-The `coin` contract removed the ability to rotate keysets since `v6`. This
+The `coin` contract removed the ability to rotate the governance predicate (e.g. a keyset) associated with a principal account since `v6`. This
 change protects users from front-running attacks and squatting attacks. To allow
 new devices to be added retroactively to an account, we need to use a principal
 type that allows keysets to be rotated. This new principal type is called the

--- a/kip-0023.md
+++ b/kip-0023.md
@@ -218,130 +218,47 @@ signature will be provided via `WebAuthn`.
 }
 ```
 
-## WebAuthn Smart Contracts
+## R:Accounts
 
-In order to manage accounts guarded by a `WebAuthn` key, two new smart contracts
-will be introduced: `webauthn-guard` and `webauthn-wallet`.
+Principal accounts don't allow keysets to be rotated. However there exists one
+principal type that facilitates this behavior, the `r:account`. An `r:account`
+is created from a `keyset-ref-guard`. To protect such keyset, users should only
+create referenced keysets on a `principal namespace`.
 
-This approach creates a thin layer of abstraction over the keysets, enabling an
-account to have multiple devices associated with it. As a result, an account is
-not restricted to the devices known at the time of registration, but retains the
-flexibility to add new devices or replace existing ones.
+### Principal namespace
 
-### WebAuthn Guard Smart Contract
+A principal namespace is created using a `keyset`, ensuring only the owner of
+that `keyset` to initialize that namespace on a chain. Initializing such keyset
+is not an intuitive process and makes the onboarding more difficult.
 
-The `webauthn-guard` contract handles account management and authorization. It
-keeps track of all the keysets associated with an account and allows users to
-configure how many keysets need to sign for authorization and additional keyset
-registration requests.
+To combat this we propose to use a `temporary keypair` to be part of the keyset
+to create the `principal namespace` and `r:account`. The wallet will be able to
+sign using the `temporary keypair` to authorize the transaction to create both
+the `principal namespace` as well as the `r:account`. This way the user does not
+need to sign for this initialization for each chain, preventing a tedious
+repetition of performing the biometric authentication for each chain.
 
-> This account architecture takes inspiration from how keysets work in Pact. For
-> example, a webauthn guard is like a multi-key keyset with a minimum approval
-> predicate, however it allows for adding additional keys in retrospect and
-> there can be custom minimum approval requirements for adding new keys.
+The `temporary keypair` should be removed and forgotten after creation of the
+account. The attack vector is therefor similar to traditional wallets during
+account and namespace creation and after the creation will be more secure as
+there will be no more `private keys` involved with authorizing these assets.
 
-The following is a snippet of the account schema from `webauthn-guard`:
+### WebAuthn Credential Ids
 
-```pact
-(defschema device-schema
-  name          : string
-  domain        : string
-  credential-id : string
-  guard         : guard
-)
+To sign for a transaction the wallet needs to initialize the transaction using
+the credential id paired with the keypair. Therefor the wallet needs to keep
+track of what credential id belongs to what public key. This can be stored
+in traditional wallets, but we propose to also store this information on chain
+to ease the process of transitioning wallets.
 
-(defschema account-schema
-  @model [
-    (invariant (> (length devices) 0))
-    (invariant (< (length devices) 5))
-    (invariant (> min-approvals 0))
-    (invariant (> min-registration-approvals 0))
-    (invariant (<= min-approvals (length devices)))
-    (invariant (<= min-registration-approvals (length devices)))
-  ]
-  devices                    : [object{device-schema}]
-  min-approvals              : integer
-  min-registration-approvals : integer
-)
-```
-
-> Note: `device` refers to a webauthn keyset in this context, however any keyset
-> can be used as a `device`.
-
-The `id` for each `webauthn-guard` account is derived from the principal of the
-keyset used to create the account. When the principal is created from the
-keyset, Pact identifies the keyset as being of the WebAuthn type and generates a
-`w:account`. Given the uniqueness of all WebAuthn keysets, only the person with
-access to the original account should be able to access the same `w:account` on
-other chains.
-
-To create the same account on different chains, we recommend using the `copy`
-function. This function recreates the account in its current state on another
-chains by executing a defpact to transfer the current `account-schema` to the
-new chain. This process acts like a new registration and requires the user to
-meet the `min-registration-approval` criteria.
+The credential information will be stored in `spirekey.pact` allowing users
+to keep track of what credential id's belong to their `r:account`.
 
 #### Registering an existing account with a new wallet
 
-Accounts created with the `webauthn-guard` contract can be accessed through
-multiple wallets. Although WebAuthn keysets are domain-specific (i.e., users can
-only sign transactions with the keysets generated on their original wallet),
-additional keysets from another wallet can be added if the registration
-requirements are met with the original wallet's keysets. This provides users
-with greater flexibility in choosing wallets and reduces dependence on any
-single wallet.
-
-### WebAuthn Wallet Smart Contract
-
-The `webauthn-wallet` contract is designed to facilitate the integration of
-webauthn-guard accounts with existing `fungible-v2` contracts.
-
-To create a `fungible-v2` account, you need to provide an account name and a
-guard. Since Pact accepts capabilities as guards, `webauthn-wallet` performs the
-following steps:
-
-- Creates a capability guard using the `w:account` from `webauthn-guard`
-- Uses the `c:account` as the guard for the `fungible-v2` account
-
-By employing a capability guard, we are able to enforce the requirements of the
-`webauthn-guard` account and use the associated keysets to secure the
-`fungible-v2` account.
-
-#### Account Management
-
-Each `webauthn-wallet` account has a `w:account` that is used as the identifier
-for the `webauthn-guard` and a `c:account` which is used for the `fungible-v2`.
-To simplify account management, `webauthn-wallet` wraps some functions, allowing
-users to only track their `c:account`. The following functions from
-`webauthn-guard` are wrapped by `webauthn-wallet`:
-
-- add-device
-- remove-device
-- copy-account
-
-#### WebAuthn Wallet Capabilities
-
-Since `fungible-v2` accounts are guarded by a capability, transactions requiring
-authentication must bring in `webauthn-wallet` capabilities into scope.
-
-Most contracts should be written with `webauthn-guard` and `webauthn-wallet` in
-mind. However, the `coin` contract, being non-upgradable, will likely not
-accommodate `webauthn-wallet` accounts. As a result, you cannot bring the
-`webauthn-wallet.DEBIT` capability into scope when using native `coin`
-functions/capabilities. To address this, the `webauthn-wallet` contract provides
-the following functions/capabilities as alternatives to their `coin`
-counterparts:
-
-- `coin.transfer` _(function)_ -> `webauthn-wallet.transfer`
-- `coin.GAS` _(capability)_ -> `webauthn-wallet.GAS_PAYER` &
-  `webauthn-wallet.GAS`
-- `coin.TRANSFER` _(capability)_ -> `webauthn-wallet.TRANSFER`
-
-> Note: Due to the way chainweb processes the `GAS_PAYER` capability,
-> `webauthn-wallet` accounts will need to sign for an additional
-> `webauthn-wallet.GAS` capability when paying for gas. We are working on a
-> solution to simplify the interface further, which will become available in the
-> next chainweb release.
+Accounts guarded by a `r:account` can rotate their keyset using any keypair.
+This includes traditional wallets or hardware wallets. Wallets have to prepare
+the keyset to be modified and rotated into the `r:account`.
 
 ## Registration flow
 
@@ -350,22 +267,19 @@ sequenceDiagram
   actor User
   participant WebAuthn(Device)
   participant WalletA.com
-  participant WebAuthn(SC)
+  participant Chainweb
   participant Fungible(SC)
+  participant SpireKey(SC)
 
   User->>+WalletA.com: I'd like to create an account named "Alice"
-  WalletA.com->>+WebAuthn(Device): Please give me a public key for Alice, c:capabilityguardforalice
+  WalletA.com->>+WebAuthn(Device): Please give me a public key for Alice
   WebAuthn(Device)->>+User: Please approve this request
   User-->>-WebAuthn(Device): I approve this request
   WebAuthn(Device)-->>-WalletA.com: Here is the public key: abc000
-  WalletA.com->>+WebAuthn(SC): What is the "c:account" for "Alice"?
-  WebAuthn(SC)-->>-WalletA.com: That would be "c:capabilityguardforalice"
-  WalletA.com->>+WebAuthn(Device): Here is the transaction to register, please sign
-  WebAuthn(Device)->>+User: Please approve this transaction
-  User-->>-WebAuthn(Device): I approve this transaction
-  WebAuthn(Device)-->>-WalletA.com: Here is the signature for the transaction
-  WalletA.com->>+WebAuthn(SC): Please register "Alice" with this public key
-  WebAuthn(SC)->>+Fungible(SC): Create an account for "c:capabilityguardforalice"
+  WalletA.com->>-WalletA.com: Generate Temporary Keypair
+  WalletA.com->>+Chainweb: Register `n_abc` namespace
+  WalletA.com->>+Fungible(SC): Register `r:account`
+  WalletA.com->>+SpireKey(SC): Register credential id with `r:account`
 ```
 
 ## Sign for transaction (dApp)
@@ -381,10 +295,10 @@ sequenceDiagram
   User->>+dApp: Hi I'm "Alice"
   dApp-->>-User: What wallet would like to use to identify yourself with?
   User->>+dApp: I'd like to use WalletA.com
-  dApp-->>-User: Please provide me account information
-  User->>+WalletA.com: Please provide my account info
-  WalletA.com-->>-User: Here is your info: abc00, c:capabilityguardforalice
-  User->>+dApp: Here are my details
+  dApp-->>-WalletA.com: Please provide me account information
+  WalletA.com-->>+User: Which account would you like to use?
+  User->>-WalletA.com: Please use this `r:account`
+  WalletA.com-->>+dApp: Here are the details
   User->>+dApp: I'd like to buy this product
   dApp-->>-User: Here is the transaction to order the product
   User->>+WalletA.com: Please sign for this transaction

--- a/kip-0023.md
+++ b/kip-0023.md
@@ -23,16 +23,17 @@ be challenging for users unfamiliar with blockchain technology:
 - Wallets often generate a 12-24 word mnemonic phrase that users need to store
   securely in addition to a traditional password.
 
-Moreover, the security of accounts generated through many existing wallets is
-centralized because the user's key pairs are generated and stored by the wallet
-provider. If the wallet provider becomes unavailable or is compromised, users
-may lose access to their assets.
+Wallets access their private keys via software. This means that if the wallet is
+compromised, the user's key pairs can be used to sign without the user's
+awareness. With Kadena SpireKey you will always be prompted to personally sign
+for every transaction, which provides more security, transparency and control.
 
-WebAuthn enables users to securely generate and store key pairs directly on
-their own hardware devices. These key pairs can typically be accessed via Touch
-ID or Face ID, allowing users to log in and sign transactions without passwords.
-Since the private key is stored on the user's hardware device and there is no
-need for storing a password, this method enhances security. Additionally, using
+Mnemonic phrases are difficult to store securely and easy to lose. WebAuthn
+enables users to securely generate and store key pairs directly on their own
+hardware devices. There is no need to remember a mnemonic phrase. These key
+pairs can typically be accessed via Touch ID or Face ID, allowing users to log
+in and sign transactions without passwords. Since access is only granted using
+biometric authentication, the need for passwords is removed. Additionally, using
 WebAuthn key pairs provides a user-friendly and convenient experience similar to
 services like Apple Pay or Google Pay.
 

--- a/kip-0023.md
+++ b/kip-0023.md
@@ -16,11 +16,11 @@ Chainweb Node and Pact smart contracts.
 
 # Motivation
 
-WebAuthn allows for users to use a hardware powered device to store keypairs securely.
-Users will be able to interact with those stored keypairs only by initiating a sign
-request from the registered web domain. The private key never leaves the device
-and the user never enters a password. This brings the user more security and convenience
-simultaneously.
+WebAuthn allows for users to use a hardware powered device to store keypairs
+securely. Users will be able to interact with those stored keypairs only by
+initiating a sign request from the registered web domain. The private key never
+leaves the device and the user never enters a password. This brings the user
+more security and convenience simultaneously.
 
 In comparison to current wallets, the wallet developers have no access to the
 private keys. The user does not have to write down their mnemonics or even enter
@@ -34,14 +34,14 @@ In the below json schema's the new or updated attributes are prefixed with a `+`
 
 ### Chainweb Node Request
 
-A WebAuthn sign request is slightly different than a usual signature. The authenticator
-signing the request appends on the `challenge` additional data. For our `ED25519` signatures
-we use the private key to sign for the `hash` as message. WebAuthn attaches the
-`authenticatorData` and `clientDataJSON` to the message before signing. That data
-will be provided along with the signature.
+A WebAuthn sign request is slightly different than a usual signature. The
+authenticator signing the request appends on the `challenge` additional data.
+For our `ED25519` signatures we use the private key to sign for the `hash` as
+message. WebAuthn attaches the `authenticatorData` and `clientDataJSON` to the
+message before signing. That data will be provided along with the signature.
 
-In order to verify the signature you therefore need to first reconstruct the message
-using the `hash`, `authenticatorData` and `clientDataJSON`.
+In order to verify the signature you therefore need to first reconstruct the
+message using the `hash`, `authenticatorData` and `clientDataJSON`.
 
 ```json
 {
@@ -59,18 +59,18 @@ using the `hash`, `authenticatorData` and `clientDataJSON`.
 
 ### Command Payload
 
-In the command payload the `signers` array provides information about the
-public key that will be signing for this request. The `scheme` should
-indicate that the signature will be provided via `WebAuthn`.
+In the command payload the `signers` array provides information about the public
+key that will be signing for this request. The `scheme` should indicate that the
+signature will be provided via `WebAuthn`.
 
-The public key should be described in base64 encoded `JWK` format. This
-allows for greater flexibility in the future when Chainweb Node decides to
-accept more algorithms. The `JWK` format allows for the clients constructing
-the request to remain blissfully unaware of what algorithm is used by the
-authenticator.
+The public key should be described in base64 encoded `JWK` format. This allows
+for greater flexibility in the future when Chainweb Node decides to accept more
+algorithms. The `JWK` format allows for the clients constructing the request to
+remain blissfully unaware of what algorithm is used by the authenticator.
 
-_NOTE: Additionally Chainweb Node could provide a new endpoint that describes which_
-_algorithms to support, using the [Allow credentials](https://www.w3.org/TR/webauthn-2/#dom-publickeycredentialrequestoptions-allowcredentials)_
+_NOTE: Additionally Chainweb Node could provide a new endpoint that describes
+which_ _algorithms to support, using the
+[Allow credentials](https://www.w3.org/TR/webauthn-2/#dom-publickeycredentialrequestoptions-allowcredentials)_
 _description._
 
 ```json
@@ -104,25 +104,109 @@ _description._
 
 ### Pact Keyset
 
-In Pact the public key should be accepted as part of any keyset.
-This allows Smart Contracts to use the registered keysets as any other
-keyset. This should not be impacting any smart contracts, other than
-more types of public keys being accepted.
-
-_NOTE: A keyset using such a base64 encoded public key might exceed_
-_the current limitations of a principaled acount length for newer algorithms_
+In Pact the public key should be accepted as part of any keyset. This allows
+Smart Contracts to use the registered keysets as any other keyset. This should
+not be impacting any smart contracts, other than more types of public keys being
+accepted. The WebAuthn key will be prefixed with `WEBAUTHN-` to allow different
+validations to be applied on the keys in `Chainweb Node` and `Pact`.
 
 ```pact
 (env-data
   { 'ks :
     { 'keys :
-    ["eyJrdHkiOiJFQyIsImFsZyI6IkVTMjU2IiwiY3J2IjoiUC0yNTYiLCJ4IjoiNy02UHRXYmxhNUdUSTJaZ3VpTU43UXhaTmZKQXlXTzAzTDRaUHVoSG5ydyIsInkiOiI0UlVuOU54eWRUdU5DOTR5YWx6RUV4c2pianJsVy1xbkV4REg0emM3aUIwIn0"]
+    ["WEBAUTHN-a50102032620012158206fb822acf87bea4a37c2d5ff067675456bd38afc4f3d43afd0c7d2c94cd997d6225820c464ff1bccf536172dea9eb37ae3bbfc411bf129afda751ea2f7faace4dbf9c8"]
     , 'pred : 'keys-all
     }
   }
 )
 (enforce-keyset (read-keyset 'ks))
 ```
+
+## WebAuthn Smart Contracts
+
+In order to manage accounts guarded by a `WebAuthn` key, two new smart contracts
+will be introduced. This is done to put a thin layer of abstraction on top of
+the keysets and allow an account to be able to have multiple devices attached in
+retrospect. This way an account is not limited to the devices known during
+registration, but keeps the ability to add more or rotate devices out of the
+guard.
+
+### WebAuthn Guard Smart Contract
+
+This smart contract is managing an account that keeps track of all keys tied to
+this account. It also allows for a user to define how many keys needs to sign
+for authorization requests and registration requests separately. The schema
+looks like:
+
+```pact
+(defschema device-schema
+  name          : string
+  domain        : string
+  credential-id : string
+  guard         : guard
+)
+(defschema account-schema
+  @model [
+    (invariant (> (length devices) 0))
+    (invariant (> min-approvals 0))
+    (invariant (> min-registration-approvals 0))
+    (invariant (<= min-approvals (length devices)))
+    (invariant (<= min-registration-approvals (length devices)))
+  ]
+  devices                    : [object{device-schema}]
+  min-approvals              : integer
+  min-registration-approvals : integer
+)
+```
+
+The id of the account is derived from the keyset defined in the first
+registration device. This will result in a `w:account`. With this device the
+account can be created on any chain and will always result in the same
+`w:account`.
+
+In the event where the first device has been lost, a user can make use of a copy
+function. The copy function will perform a `defpact` where the account state of
+any given chain will be copied over to a new chain. The user will have to sign
+with enough keys to satisfy the amount of keys defined with the
+`min-registration-approvals` setting.
+
+### WebAuthn Wallet Smart Contract
+
+This smart contract is a thin wrapper around the `WebAuthn Guard` contract and
+`fungible-v2` contract references. Based on the `w:account` created in the
+`WebAuthn Guard` contract a new `c:account` will be created in the
+`WebAuthn Wallet` contract. The capability to guard the `fungible-v2` accounts
+will inherit the principal properties from the `WebAuthn Guard` account and make
+sure that account ownership is protected using the same mechanism.
+
+#### WebAuthn Wallet Capabilities
+
+The `WebAuthn Wallet` capablities will guard the actions of the account. The
+main capability to guard the account is based on: `DEBIT`. This capability has
+the `w:account` as parameter. To make sure end users are not required to
+understand all the concepts, we have split the capabilities they will sign for.
+Those capabilities will provide an abstraction on top of the `w:account`.
+
+Users will be presented with the `TRANSFER` capability. This capability will
+expect the user's `c:account` the `account` of the receiver known in the
+`fungible-v2` contract and the `amount` to transfer. So the capability to sign
+would look like:
+
+```pact
+(n_56...bc.webauthn-wallet.TRANSFER "c:LR1...Dx0" "any-account" 1.0)
+```
+
+Additionally the `WebAuthn Wallet` contract will provide for some easy wrappers
+around management functions of the `WebAuthn Guard` contract. This way the end
+users can manage their `WebAuthn Guard` without the burden of knowing the
+`w:account` and all they need to keep track of is the `c:account`
+
+The `WebAuthn Wallet` will wrap the following functions from the
+`WebAuthn Guard`:
+
+- add-device
+- remove-device
+- copy-account
 
 ## Registration flow
 
@@ -205,4 +289,55 @@ sequenceDiagram
   WalletA.com-->>-User: Here is the tx with signature
   User->>+dApp: Here is the tx with signature
   dApp->>+Chainweb: Submitting tx
+```
+
+## Sign flow Traditional Wallet
+
+```mermaid
+flowchart TB
+
+subgraph dApp
+end
+
+subgraph Chainweb
+end
+
+subgraph SE/TEE
+  a(KeyStore)
+  b(Sign)
+  b -- Sign with KeyPair known in Wallet --> a
+end
+subgraph Wallet
+  c(KeyStore)
+  d(Sign)
+  d -- Sign with KeyPair known on chain --> c
+end
+
+dApp -- Sign Transaction --> Wallet
+Wallet -- Sign Authentication Challenge --> SE/TEE
+SE/TEE -- Send Authentication Signature --> Wallet
+Wallet -- Send Transaction Signature --> Chainweb
+```
+
+## Sign flow WebAuthn Wallet
+
+```mermaid
+flowchart TB
+
+subgraph dApp
+end
+
+subgraph Chainweb
+end
+
+subgraph SE/TEE
+  a(KeyStore)
+end
+subgraph Wallet
+end
+
+dApp -- Sign Transaction --> Wallet
+Wallet -- Sign Transaction --> SE/TEE
+SE/TEE -- Send Transaction Signature --> Wallet
+Wallet -- Send Transaction Signature --> Chainweb
 ```

--- a/kip-0023.md
+++ b/kip-0023.md
@@ -266,7 +266,7 @@ The following is a snippet of the account schema from `webauthn-guard`:
 ```
 
 > Note: `device` refers to a webauthn keyset in this context, however any keyset
-> can be used as a `device`. (I think we should update it to keyset?)
+> can be used as a `device`.
 
 The `id` for each `webauthn-guard` account is derived from the principal of the
 keyset used to create the account. When the principal is created from the
@@ -333,8 +333,15 @@ the following functions/capabilities as alternatives to their `coin`
 counterparts:
 
 - `coin.transfer` _(function)_ -> `webauthn-wallet.transfer`
-- `coin.GAS` _(capability)_ -> `webauthn-wallet.GAS_PAYER`
+- `coin.GAS` _(capability)_ -> `webauthn-wallet.GAS_PAYER` &
+  `webauthn-wallet.GAS`
 - `coin.TRANSFER` _(capability)_ -> `webauthn-wallet.TRANSFER`
+
+> Note: Due to the way chainweb processes the `GAS_PAYER` capability,
+> `webauthn-wallet` accounts will need to sign for an additional
+> `webauthn-wallet.GAS` capability when paying for gas. We are working on a
+> solution to simplify the interface further, which will become available in the
+> next chainweb release.
 
 ## Registration flow
 


### PR DESCRIPTION
# Abstract

We propose to use WebAuthn signatures as an alternative option to the current
ED25519 signatures to allow users to approve for transactions processed through
Chainweb Node and Pact smart contracts.

# Motivation

WebAuthn allows for users to use a hardware powered device to store keypairs securely.
Users will be able to interact with those stored keypairs only by initiating a sign
request from the registered web domain. The private key never leaves the device
and the user never enters a password. This brings the user more security and convenience
simultaneously.

In comparison to current wallets, the wallet developers have no access to the
private keys. The user does not have to write down their mnemonics or even enter
their password to decrypt their privatekeys.

**edit 2024-08-06**: Updated the design to use `r:accounts`. This allows us to replace the need of 2 complex smart contracts with just a single straight forward table holding credential pair and leverage the existing security features of an `r:account`. This allows other smart contracts to interact with accounts governed by SpireKey with no additional code as this is no longer governed via a smart contract.