### PR TITLE
KIP-0029: Proposal of new guard type: Constant boolean guard

### DIFF
--- a/kip-0029.md
+++ b/kip-0029.md
@@ -1,0 +1,92 @@
+---
+KIP: "0029"
+Title: Constant Boolean Guards
+Author: CryptoPascal
+Status: Draft
+Type: Standard
+Category: Pact
+Created: 2024-02-14
+---
+
+## Abstract
+
+The Proposal is to add a new type of guards in Pact:
+**Constant boolean guards**.
+
+
+## Motivation
+
+Very often it's necessary to create "always success" or "always fail" guards.
+Some examples are:
+- Definition of free but non-rotatable namespaces.
+- Default guards in smart-contracts.
+- Burn accounts
+- Temporary accounts
+- and more ...
+
+Currently the main adopted workaround is to use an user guard with a function that:
+ - returns true for "Always success"
+ - enforce false for "Always fail"
+
+But the workaround is not perfect. A user has to dig into the module code, verify whether the module is upgradable. And it definitively lacks of clarity for most people.
+
+
+We need an unambiguously way to express, identify and give a guarantee of immutability of such conditions.  
+
+## Specification
+
+#### Pact function
+The proposed interface for the new native is as follows:
+
+```pact
+(create-boolean-guard b)
+```
+`b <bool> -> <guard>`
+
+where b is a boolean: `true` or `false`
+
+### Behaviour
+
+The guard must always pass if created with "True", and always fail if created with "False"
+
+
+```pact
+(enforce-guard (create-boolean-guard true))
+  > true
+```
+
+```pact
+(enforce-guard (create-boolean-guard false))
+  > Error: Boolean guard failure.
+````
+
+#### Principal
+
+The corresponding principal uses the `b` prefix, followed by true or false.
+
+```pact
+(create-principal (create-boolean-guard true)))
+  > "b:true"
+```
+
+```pact
+(create-principal (create-boolean-guard false)))
+  > "b:false"
+```
+
+
+#### Pact value
+
+The Pact value encoding of this new guard is:
+
+```json
+{
+  "constantBool": b
+}
+```
+where b is a JSON boolean.
+
+
+## Backwards Compatibility
+
+Introducing a new native doesn't cause backward compatibility issues.


### PR DESCRIPTION
The idea is to propose a new guard, the most simple as possible, the easiest to understand.

But it's currently missing, and would be very useful, and would improve the clarity.
Nothing revolutionary.

https://github.com/CryptoPascal31/KIPs/blob/119fe2df7df6a42bba7f46c406ca631aec95e99a/kip-0029.md





 
